### PR TITLE
Mapping icons for "AppDialer Pro" and "Cherrygram" to existing ones

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -29722,6 +29722,12 @@
 	
 	<!-- Homebase -->
 	<item component="ComponentInfo{com.joinhomebase.homebase.homebase/com.joinhomebase.homebase.homebase.feature.splash.StarterActivity}" drawable="homebase"/>
+	
+	<!-- AppDialer Pro -->
+ 	<item component="ComponentInfo{name.pilgr.appdialer.pro/name.pilgr.appdialer.AppDialer}" drawable="simpleapplauncher"/>
+
+	<!-- Cherrygram (alternative Telegram client) with native TG icons -->
+	<item component="ComponentInfo{uz.unnarsx.cherrygram/uz.unnarsx.cherrygram.Old_Icon}" drawable="telegram"/>
 
 	<!-- RWTH-App -->
 	<item component="ComponentInfo{de.rwth_aachen.rz.rwthapp/de.rwth_aachen.rz.rwthapp.MainActivity}" drawable="rwthapp"/>
@@ -29737,11 +29743,5 @@
 
 	<!-- Deliveroo Rider -->
  	<item component="ComponentInfo{com.deliveroo.driverapp/com.deliveroo.driverapp.feature.launch.ui.LaunchActivity}" drawable="deliveroo_rider"/>
-
-	<!-- AppDialer Pro -->
- 	<item component="ComponentInfo{name.pilgr.appdialer.pro/name.pilgr.appdialer.AppDialer}" drawable="simpleapplauncher"/>
-
-	<!-- Cherrygram (alternative Telegram client) with native TG icons -->
-	<item component="ComponentInfo{uz.unnarsx.cherrygram/uz.unnarsx.cherrygram.Old_Icon}" drawable="telegram"/>
 
 </resources>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -29738,4 +29738,10 @@
 	<!-- Deliveroo Rider -->
  	<item component="ComponentInfo{com.deliveroo.driverapp/com.deliveroo.driverapp.feature.launch.ui.LaunchActivity}" drawable="deliveroo_rider"/>
 
+	<!-- AppDialer Pro -->
+ 	<item component="ComponentInfo{name.pilgr.appdialer.pro/name.pilgr.appdialer.AppDialer}" drawable="simpleapplauncher"/>
+
+	<!-- Cherrygram (alternative Telegram client) with native TG icons -->
+	<item component="ComponentInfo{uz.unnarsx.cherrygram/uz.unnarsx.cherrygram.Old_Icon}" drawable="telegram"/>
+
 </resources>


### PR DESCRIPTION
* AppDialer Pro is a simple tool to quickly launch application (T9-like) and the original icon looks exactly as the existing one for SimpleAppLauncher, so mapped those together
* Cherrygram is an alternative Telegram client and has a mode to use Telegram stock icons, so mapping that main with an existing one.