### PR TITLE
Requests that already have an icon, but have different package name

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -1114,6 +1114,7 @@
 
 	<!-- Alfa Bank -->
 	<item component="ComponentInfo{ru.alfabank.mobile.android/ru.alfabank.mobile.android.splash.presentation.activity.SplashActivity}" drawable="alfa_bank"/>
+	<item component="ComponentInfo{ru.alfabank.mobile.android.huawei/ru.alfabank.mobile.android.splash.presentation.activity.SplashActivity}" drawable="alfa_bank"/>
 
 	<!-- Alfagift -->
 	<item component="ComponentInfo{com.alfamart.alfagift/com.alfamart.alfagift.screen.splash.SplashActivity}" drawable="alfagift"/>
@@ -1616,6 +1617,7 @@
 	<item component="ComponentInfo{com.rovio.abclassic22/com.unity3d.player.UnityPlayerActivity}" drawable="angry_birds"/>
 	<item component="ComponentInfo{com.rovio.abcasual/com.unity3d.player.UnityPlayerActivity}" drawable="angry_birds"/>
 	<item component="ComponentInfo{com.rovio.angrybirds/com.rovio.fusion.App}" drawable="angry_birds"/>
+	<item component="ComponentInfo{com.rovio.angrybirdsseasons/com.rovio.fusion.App}" drawable="angry_birds"/>
 
 	<!-- Angry Birds 2 -->
 	<item component="ComponentInfo{com.rovio.baba/com.unity3d.player.UnityPlayerActivity}" drawable="angry_birds_2"/>
@@ -1712,6 +1714,8 @@
 
 	<!-- Another Term -->
 	<item component="ComponentInfo{green_green_avk.anotherterm/green_green_avk.anotherterm.SessionsActivity}" drawable="anotherterm"/>
+	<item component="ComponentInfo{green_green_avk.anotherterm.redist/green_green_avk.anotherterm.SessionsActivity}" drawable="anotherterm"/>
+
 
 	<!-- Another Widget -->
 	<item component="ComponentInfo{com.tommasoberlose.anotherwidget/com.tommasoberlose.anotherwidget.ui.activities.MainActivity}" drawable="another_widget"/>
@@ -1890,6 +1894,7 @@
 	<!-- APKUpdater -->
 	<item component="ComponentInfo{com.apkupdater/com.apkupdater.activity.MainActivity}" drawable="apkupdater"/>
 	<item component="ComponentInfo{com.apkupdater/com.apkupdater.ui.activity.MainActivity}" drawable="apkupdater"/>
+	<item component="ComponentInfo{com.apkupdater3/com.apkupdater.ui.activity.MainActivity}" drawable="apkupdater"/>
 
 	<!-- APlayer -->
 	<item component="ComponentInfo{remix.myplayer/remix.myplayer.ui.activity.MainActivity}" drawable="aplayer"/>
@@ -2338,6 +2343,8 @@
 	<item component="ComponentInfo{com.audible.application/com.audible.application.SplashScreen}" drawable="audible"/>
 	<item component="ComponentInfo{com.audible.application.kindle/com.audible.application.SplashScreen}" drawable="audible"/>
 	<item component="ComponentInfo{com.audible.universal/com.audible.application.SplashScreen}" drawable="audible"/>
+	<item component="ComponentInfo{com.audible.application.samsung/com.audible.application.SplashScreen}" drawable="audible"/>
+
 
 	<!-- Audile -->
 	<item component="ComponentInfo{com.mrsep.musicrecognizer/com.mrsep.musicrecognizer.presentation.MainActivity}" drawable="audile"/>
@@ -3628,6 +3635,8 @@
 	<item component="ComponentInfo{org.blokada.origin.alarm/ui.MainActivity}" drawable="blokada_alt"/>
 	<item component="ComponentInfo{org.blokada.fyra/core.PanelActivity}" drawable="blokada"/>
 	<item component="ComponentInfo{org.blokada.alarm.dnschanger/ui.MainActivity}" drawable="blokada"/>
+	<item component="ComponentInfo{org.blokada.sex/ui.MainActivity}" drawable="blokada"/>
+
 
 	<!-- Blood Donor -->
 	<item component="ComponentInfo{com.cube.arc.blood/com.cube.arc.blood.BootActivity}" drawable="blood_donor"/>
@@ -4724,6 +4733,7 @@
 	<item component="ComponentInfo{com.zui.camera/com.zui.camera.CameraLauncher}" drawable="camera"/>
 	<item component="ComponentInfo{com.ss.android.ugc.aweme/com.ss.android.ugc.aweme.splash.SplashActivity}" drawable="camera"/>
 	<item component="ComponentInfo{com.android.MGC_9_1_098/com.android.camera.CameraLauncher}" drawable="camera"/>
+	<item component="ComponentInfo{photography.sweet.selfie.camera/com.ijoysoft.camera.activity.WelcomeActivity}" drawable="camera"/>
 
 	<!-- Camera Connect -->
 	<item component="ComponentInfo{jp.co.canon.ic.cameraconnect/jp.co.canon.ic.cameraconnect.top.CCTopActivity}" drawable="cameraconnect"/>
@@ -4971,6 +4981,8 @@
 
 	<!-- Cataclysm DDA -->
 	<item component="ComponentInfo{com.cleverraven.cataclysmdda/com.cleverraven.cataclysmdda.SplashScreen}" drawable="cataclysm_dda"/>
+	<item component="ComponentInfo{com.cleverraven.cataclysmdda.experimental/com.cleverraven.cataclysmdda.SplashScreen}" drawable="cataclysm_dda"/>
+
 
 	<!-- Catan Dice Game -->
 	<item component="ComponentInfo{com.ridgelineapps.resdicegame/com.ridgelineapps.resdicegame.MainActivity}" drawable="catandicegame"/>
@@ -5031,6 +5043,7 @@
 
 	<!-- CDisplayEx -->
 	<item component="ComponentInfo{com.progdigy.cdisplay/com.progdigy.cdisplay.SplashActivity}" drawable="cdisplayex"/>
+	<item component="ComponentInfo{com.progdigy.cdisplay.free/com.progdigy.cdisplay.SplashActivity}" drawable="cdisplayex"/>
 
 	<!-- CE Lighting -->
 	<item component="ComponentInfo{com.bolutek.iglootest/com.bolutek.iglootest.ui.activitys.AppStartActivity}" drawable="celighting"/>
@@ -5587,6 +5600,9 @@
 	<item component="ComponentInfo{com.android.deskclock/com.android.deskclock.AlarmMainActivity}" drawable="clock"/>
 	<item component="ComponentInfo{com.philliphsu.clock2/com.philliphsu.clock2.MainActivity}" drawable="clock"/>
 	<item component="ComponentInfo{net.xisberto.timerpx/net.xisberto.timerpx.MainActivity}" drawable="clock"/>
+	<item component="ComponentInfo{com.hihonor.deskclock/com.android.deskclock.AlarmsMainActivity}" drawable="clock"/>
+
+	<!-- Clockify -->
 
 	<!-- Clockify -->
 	<item component="ComponentInfo{me.clockify.android/me.clockify.android.presenter.SplashActivity}" drawable="clockify"/>
@@ -6987,6 +7003,7 @@
 	<item component="ComponentInfo{com.dic_o.dico_eng_spa/com.dic_o.dico_universal.DICoActivity}" drawable="dictionary"/>
 	<item component="ComponentInfo{com.dic_o.dico_svk_ger/com.dic_o.dico_universal.DICoActivity}" drawable="dictionary"/>
 	<item component="ComponentInfo{com.mobisystems.msdict.embedded.wireless.oxford.dictionaryofenglish/com.mobisystems.base_dict_plugin.MainActivity}" drawable="dictionary" />
+	<item component="ComponentInfo{com.dic_o.dico_cze_ger/com.dic_o.dico_universal.DICoActivity}" drawable="dictionary" />
 
 	<!-- Dictionary.com -->
 	<item component="ComponentInfo{com.dictionary/com.dictionary.MainActivity}" drawable="dictionary_com"/>
@@ -7385,7 +7402,9 @@
 	<item component="ComponentInfo{com.Dominos/com.Dominos.activity.alias.LauncherDefaultAlias}" drawable="dominos"/>
 	<item component="ComponentInfo{com.Dominos/com.Dominos.activity.alias.LauncherDiwaliAlias}" drawable="dominos"/>
 	<item component="ComponentInfo{com.Dominos/com.Dominos.activity.alias.LauncherNewYearAlias}" drawable="dominos"/>
-	<item component="ComponentInfo{com.Dominos/com.Dominos.activity.alias.LauncherChristmasAlias}" drawable="dominos" />
+	<item component="ComponentInfo{com.Dominos/com.Dominos.activity.alias.LauncherChristmasAlias}" drawable="dominos"/>
+	<item component="ComponentInfo{com.dominos.dominossite/com.arizona.MainActivity}" drawable="dominos" />
+
 
 	<!-- Dont Starve -->
 	<item component="ComponentInfo{com.kleientertainment.doNotStarvePocket/com.kleientertainment.doNotStarvePocket.DoNotStarveActivity}" drawable="dont_starve"/>
@@ -8723,6 +8742,7 @@
 	<!-- FDE.AI -->
 	<item component="ComponentInfo{com.feravolt.fdeai/com.feravolt.fdeai.activities.MainActivity}" drawable="fdeai"/>
 	<item component="ComponentInfo{com.feravolt.fdeai/com.feravolt.fdeai.ui.MainActivity}" drawable="fdeai"/>
+	<item component="ComponentInfo{com.iouchhggaz.knviwezbyk/com.feravolt.fdeai.ui.MainActivity}" drawable="fdeai"/>
 
 	<!-- FDJ -->
 	<item component="ComponentInfo{fr.fdj.apps.fdj/fr.fdj.apps.maitre.ui.activities.SplashScreenActivity}" drawable="fdj"/>
@@ -11187,6 +11207,7 @@
 
 	<!-- Godville -->
 	<item component="ComponentInfo{ru.godville.android/ru.godville.android4.base.activities.LaunchActivity}" drawable="godville"/>
+	<item component="ComponentInfo{com.godvillegame.android/ru.godville.android4.base.activities.LaunchActivity}" drawable="godville"/>
 
 	<!-- Goibibo -->
 	<item component="ComponentInfo{com.goibibo/com.goibibo.common.HomeActivity}" drawable="goibibo"/>
@@ -11506,6 +11527,7 @@
 	<item component="ComponentInfo{us.spotco.mulch_wv/org.chromium.android_webview.devui.LauncherActivity}" drawable="google_webview_devtools"/>
 	<item component="ComponentInfo{us.spotco.mulch_wv/org.chromium.android_webview.devui.MainActivity}" drawable="google_webview_devtools"/>
 	<item component="ComponentInfo{com.android.webview/org.chromium.android_webview.devui.MainActivity}" drawable="google_webview_devtools"/>
+	<item component="ComponentInfo{com.google.android.webview.beta/org.chromium.android_webview.devui.LauncherActivity}" drawable="google_webview_devtools"/>
 
 	<!-- Google WebView DevTools Beta -->
 	<item component="ComponentInfo{com.google.android.webview.canary/org.chromium.android_webview.devui.LauncherActivity}" drawable="google_webview_devtools_beta"/>
@@ -12893,6 +12915,9 @@
 	<item component="ComponentInfo{ml.docilealligator.infinityforreddit/ml.docilealligator.infinityforreddit.activities.MainActivity}" drawable="infinity"/>
 	<item component="ComponentInfo{ml.docilealligator.infinityforreddit.plus/ml.docilealligator.infinityforreddit.activities.MainActivity}" drawable="infinity"/>
 	<item component="ComponentInfo{gripe.everything.infinityforeverything/ml.docilealligator.infinityforreddit.activities.MainActivity}" drawable="infinity"/>
+	<item component="ComponentInfo{ml.docilealligator.redditforinfinity/ml.docilealligator.infinityforreddit.activities.MainActivity}" drawable="infinity"/>
+
+	<!-- Inflow -->
 
 	<!-- Inflow -->
 	<item component="ComponentInfo{inflow.adhd.productivity/inflow.adhd.productivity.MainActivity}" drawable="inflow"/>
@@ -13518,6 +13543,8 @@
 	<item component="ComponentInfo{com.grubhub.android/com.grubhub.dinerapp.android.splash.SplashActivity}" drawable="just_eat"/>
 	<item component="ComponentInfo{at.lieferservice.android/com.takeaway.android.activity.Splash}" drawable="just_eat"/>
 	<item component="ComponentInfo{be.pizza.android/com.takeaway.android.activity.Splash}" drawable="just_eat"/>
+	<item component="ComponentInfo{com.justeat.app.fr/com.takeaway.android.activity.Splash}" drawable="just_eat"/>
+
 
 	<!-- Just Player -->
 	<item component="ComponentInfo{com.brouken.player/com.brouken.player.PlayerActivity}" drawable="mediaplayer"/>
@@ -14528,6 +14555,8 @@
 	<item component="ComponentInfo{com.freestylelibre3.app.fr/com.adc.trident.app.startup.SplashActivity}" drawable="libre_3"/>
 	<item component="ComponentInfo{com.freestylelibre3.app.nl/com.adc.trident.app.startup.SplashActivity}" drawable="libre_3"/>
 	<item component="ComponentInfo{com.freestylelibre3.app.de/com.adc.trident.app.startup.SplashActivity}" drawable="libre_3"/>
+	<item component="ComponentInfo{com.freestylelibre3.app.us/com.adc.trident.app.startup.SplashActivity}" drawable="libre_3"/>
+
 
 	<!-- Libre Camera -->
 	<item component="ComponentInfo{com.iakmds.librecamera/com.iakmds.librecamera.MainActivity}" drawable="camera"/>
@@ -14547,6 +14576,8 @@
 	<!-- LibreLink -->
 	<item component="ComponentInfo{com.freestylelibre.app.fr/com.librelink.app.ui.SplashActivity}" drawable="librelink"/>
 	<item component="ComponentInfo{com.freestylelibre.app.nl/com.librelink.app.ui.SplashActivity}" drawable="librelink"/>
+	<item component="ComponentInfo{com.freestylelibre.app.gr/com.librelink.app.ui.SplashActivity}" drawable="librelink"/>
+
 
 	<!-- Librem Chat -->
 	<item component="ComponentInfo{one.librem.chat/im.vector.activity.VectorLauncherActivity}" drawable="libremchat"/>
@@ -14768,6 +14799,7 @@
 
 	<!-- Link eye -->
 	<item component="ComponentInfo{kuesji.link_eye/kuesji.link_eye.Main}" drawable="linkeye"/>
+	<item component="ComponentInfo{kuesji.link_eye.fdroid/kuesji.link_eye.Main}" drawable="linkeye"/>
 
 	<!-- Link Now -->
 	<item component="ComponentInfo{com.huawei.welinknow/com.huawei.welinklite.MainActivity}" drawable="link_now"/>
@@ -14887,6 +14919,8 @@
 
 	<!-- Литрес: Книги (Litres: Books) -->
 	<item component="ComponentInfo{ru.litres.android/ru.litres.android.splash.MainSplashAlias}" drawable="litresb"/>
+	<item component="ComponentInfo{ru.litres.android.global/ru.litres.android.splash.MainSplashAlias}" drawable="litresb"/>
+
 
 	<!-- LLCrop (lossless) -->
 	<item component="ComponentInfo{de.k3b.android.lossless_jpg_crop/de.k3b.android.lossless_jpg_crop.CropAreasEditActivity}" drawable="llcroplossless"/>
@@ -14982,6 +15016,7 @@
 
 	<!-- Loklok -->
 	<item component="ComponentInfo{com.artem.scotepio/com.loklok.flash.android.MainActivity}" drawable="loklok"/>
+	<item component="ComponentInfo{com.tv.loklok/com.loklok.flash.android.MainActivity}" drawable="loklok"/>
 
 	<!-- Lona -->
 	<item component="ComponentInfo{io.github.lufte.lona/io.github.lufte.lona.MainActivity}" drawable="lona"/>
@@ -15595,6 +15630,8 @@
 	<!-- MediaMarkt -->
 	<item component="ComponentInfo{tr.com.media.markt/com.mediasaturn.app.splashscreen.SplashScreenActivity}" drawable="mediamarkt"/>
 	<item component="ComponentInfo{com.media.markt/com.mediamarkt.mms_oscapps_flutter.MainActivity}" drawable="mediamarkt"/>
+	<item component="ComponentInfo{nl.com.media.markt/com.mediamarkt.mms_oscapps_flutter.MainActivity}" drawable="mediamarkt"/>
+
 
 	<!-- MediaMonkey -->
 	<item component="ComponentInfo{com.ventismedia.android.mediamonkey/com.ventismedia.android.mediamonkey.StartActivity}" drawable="mediamonkey"/>
@@ -16023,6 +16060,9 @@
 	<item component="ComponentInfo{com.google.android.gms/org.microg.gms.ui.SettingsActivity}" drawable="microgsettings"/>
 	<item component="ComponentInfo{com.google.android.gms/org.microg.gms.ui.SettingsActivityLauncher}" drawable="microgsettings"/>
 	<item component="ComponentInfo{com.mgoogle.android.gms/org.microg.gms.ui.MainSettingsActivity}" drawable="microgsettings"/>
+	<item component="ComponentInfo{app.revanced.android.gms/org.microg.gms.ui.SettingsActivity}" drawable="microgsettings"/>
+
+	<!-- Microsoft 365 -->
 
 	<!-- Microsoft 365 -->
 	<item component="ComponentInfo{com.microsoft.office.officehubrow/com.microsoft.office.officesuite.OfficeSuiteActivity}" drawable="microsoft_365"/>
@@ -16237,6 +16277,8 @@
 
 	<!-- Mini Militia -->
 	<item component="ComponentInfo{com.appsomniacs.da2/com.appsomniacs.da2.DA2Activity}" drawable="mini_militia"/>
+	<item component="ComponentInfo{com.minimilitia.undeectablemod.byneerajmods/com.appsomniacs.da2.DA2Activity}" drawable="mini_militia"/>
+
 
 	<!-- Minidoro -->
 	<item component="ComponentInfo{com.github.ympavlov.minidoro/com.github.ympavlov.minidoro.PomodoroActivity}" drawable="minidoro"/>
@@ -16473,6 +16515,8 @@
 	<!-- Mobizen -->
 	<item component="ComponentInfo{com.rsupport.mobizen.lg/com.rsupport.mvagent.ui.activity.splash.SplashActivity}" drawable="mobizen"/>
 	<item component="ComponentInfo{com.rsupport.mvagent/com.rsupport.mvagent.ui.activity.splash.SplashActivity}" drawable="mobizen"/>
+	<item component="ComponentInfo{com.rsupport.mobizen.sec/com.rsupport.mvagent.ui.activity.splash.SplashActivity}" drawable="mobizen"/>
+
 
 	<!-- MobMuPlat -->
 	<item component="ComponentInfo{com.iglesiaintermedia.mobmuplat/com.iglesiaintermedia.mobmuplat.MainActivity}" drawable="mobmuplat"/>
@@ -16519,6 +16563,7 @@
 	<!-- Moj A1 -->
 	<item component="ComponentInfo{hr.infinum.mojvip/hr.infinum.mojvip.activities.PreloadingActivity}" drawable="moj_a1"/>
 	<item component="ComponentInfo{rs.vipmobile.mojvip2/com.tag.selfcare.tagselfcare.Launcher}" drawable="moj_a1"/>
+	<item component="ComponentInfo{by.a1.selfcare/com.tag.selfcare.tagselfcare.Launcher}" drawable="moj_a1"/>
 
 	<!-- MOJ M -->
 	<item component="ComponentInfo{si.mercator.mojm/si.mercator.mojm.MainActivity}" drawable="mojm"/>
@@ -16999,6 +17044,10 @@
 	<item component="ComponentInfo{com.musicplan.playermusic/com.musicplan.playermusic.activities.MainActivity}" drawable="music"/>
 	<item component="ComponentInfo{com.atul.musicplayer/com.atul.musicplayer.MainActivity}" drawable="music"/>
 	<item component="ComponentInfo{com.appums.music_pitcher/com.appums.music_pitcher.Main}" drawable="music"/>
+	<item component="ComponentInfo{com.realme.as.music/com.nearme.music.splash.SplashActivity}" drawable="music"/>
+	<item component="ComponentInfo{media.audioplayer.musicplayer/com.ijoysoft.music.activity.WelcomeActivity}" drawable="music"/>
+	<item component="ComponentInfo{audioplayer.free.music.player/com.ijoysoft.music.activity.WelcomeActivity}" drawable="music"/>
+
 
 	<!-- Music Downloader -->
 	<item component="ComponentInfo{com.msplayerops.mymusicfpeapp/com.msplayerops.mymusicfpeapp.activity.SplashActivity}" drawable="music_downloader"/>
@@ -17120,6 +17169,8 @@
 
 	<!-- My BMW -->
 	<item component="ComponentInfo{de.bmw.connected.mobile20.row/com.mobileconnected.MainActivity}" drawable="bmw"/>
+	<item component="ComponentInfo{de.bmw.connected.mobile20.na/com.mobileconnected.MainActivity}" drawable="bmw"/>
+	<item component="ComponentInfo{de.bmw.connected.mobile20.cn/com.mobileconnected.MainActivity}" drawable="bmw"/>
 
 	<!-- My Boy! -->
 	<item component="ComponentInfo{com.fastemulator.gba/com.fastemulator.gba.MainActivity}" drawable="my_boy"/>
@@ -17214,11 +17265,13 @@
 
 	<!-- My Orange -->
 	<item component="ComponentInfo{com.orange.mobinilandme/com.linkdev.mobinilandme.ui.SplashScreen}" drawable="my_orange"/>
-
-	<!-- My Orange -->
 	<item component="ComponentInfo{com.orange.myorange.omd/com.orange.omnis.main.ui.MainActivity}" drawable="my_orange"/>
 	<item component="ComponentInfo{com.orange.contultauorange/com.orange.contultauorange.activity.EntryActivity}" drawable="my_orange"/>
 	<item component="ComponentInfo{pl.orange.mojeorange/crc646bf5eb75cfbff4ee.SplashScreen}" drawable="my_orange"/>
+	<item component="ComponentInfo{com.orange.myorange.otn/com.orange.omnis.main.ui.MainActivity}" drawable="my_orange"/>
+	<item component="ComponentInfo{sk.orange.android.orangego/com.orange.omnis.main.ui.MainActivity}" drawable="my_orange"/>
+	<item component="ComponentInfo{com.orange.myorange.ojo/com.orange.omnis.main.ui.MainActivity}" drawable="my_orange"/>
+
 
 	<!-- My Passport Wireless -->
 	<item component="ComponentInfo{com.wdc.wd2go/com.wdc.wd2go.ui.activity.SplashActivity}" drawable="my_passport_wireless"/>
@@ -17833,6 +17886,8 @@
 	<!-- Neo Backup -->
 	<item component="ComponentInfo{com.machiav3lli.backup/com.machiav3lli.backup.activities.SplashActivity}" drawable="neo_backup"/>
 	<item component="ComponentInfo{com.machiav3lli.backup/com.machiav3lli.backup.activities.MainActivityX}" drawable="neo_backup"/>
+	<item component="ComponentInfo{com.machiav3lli.backup.neo/com.machiav3lli.backup.activities.SplashActivity}" drawable="neo_backup"/>
+
 
 	<!-- Neo Feed -->
 	<item component="ComponentInfo{com.saulhdev.neofeed/com.saulhdev.feeder.MainActivity}" drawable="neo_feed"/>
@@ -18215,6 +18270,7 @@
 
 	<!-- Ning -->
 	<item component="ComponentInfo{de.csicar.ning/de.csicar.ning.MainActivity}" drawable="ning"/>
+	<item component="ComponentInfo{com.zuccaro.ning/de.csicar.ning.MainActivity}" drawable="ning"/>
 
 	<!-- Nintendo Switch Online -->
 	<item component="ComponentInfo{com.nintendo.znca/com.nintendo.coral.ui.boot.BootActivity}" drawable="nintendo_switch_online"/>
@@ -18993,15 +19049,18 @@
 
 	<!-- Open Camera -->
 	<item component="ComponentInfo{net.sourceforge.opencamera/net.sourceforge.opencamera.MainActivity}" drawable="opencamera"/>
+	<item component="ComponentInfo{com.iode.opencamera/net.sourceforge.opencamera.MainActivity}" drawable="opencamera"/>
 
 	<!-- Open Chaos Chess -->
 	<item component="ComponentInfo{dev.corruptedark.openchaoschess/dev.corruptedark.openchaoschess.MainActivity}" drawable="openchaoschess"/>
 
 	<!-- Open Connect -->
 	<item component="ComponentInfo{app.openconnect/app.openconnect.MainActivity}" drawable="openconnect"/>
+	<item component="ComponentInfo{com.github.digitalsoftwaresolutions.openconnect/app.openconnect.MainActivity}" drawable="openconnect"/>
 
 	<!-- Open Contacts -->
 	<item component="ComponentInfo{opencontacts.open.com.opencontacts/opencontacts.open.com.opencontacts.activities.MainActivity}" drawable="opencontacts"/>
+	<item component="ComponentInfo{opencontacts.open.com.opencontacts.debug/opencontacts.open.com.opencontacts.activities.MainActivity}" drawable="opencontacts"/>
 
 	<!-- Open Flashlight -->
 	<item component="ComponentInfo{io.github.sanbeg.flashlight/io.github.sanbeg.flashlight.FlashLightActivity}" drawable="openflashlight"/>
@@ -20155,6 +20214,8 @@
 	<item component="ComponentInfo{ch.raiffeisen.phototan/ch.raiffeisen.phototan.RoutingActivity}" drawable="phototan"/>
 	<item component="ComponentInfo{com.db.pbc.phototan.db/com.db.pbc.phototan.db.activities.splash.SplashActivity}" drawable="phototan_deutsche_bank"/>
 	<item component="ComponentInfo{ch.raiffeisen.phototan/ch.raiffeisen.phototan.launcher_d90f20b5c6deefc23e8f5b77920bb46e9037d859a1a4acee852652fc8083c238}" drawable="phototan"/>
+	<item component="ComponentInfo{com.db.pbc.phototan.nb/com.db.pbc.phototan.db.activities.splash.SplashActivity}" drawable="phototan"/>
+
 
 	<!-- Phyphox -->
 	<item component="ComponentInfo{de.rwth_aachen.phyphox/de.rwth_aachen.phyphox.ExperimentList}" drawable="phyphox"/>
@@ -20201,6 +20262,8 @@
 	<item component="ComponentInfo{com.picsart.studio/com.socialin.android.photo.picsinphoto.MainActivity}" drawable="picsart"/>
 	<item component="ComponentInfo{com.picsart.studio/com.socialin.android.photo.picsinphoto.MainPagerActivity}" drawable="picsart"/>
 	<item component="ComponentInfo{com.picsart.studio/com.google.android.archive.ReactivateActivity}" drawable="picsart"/>
+	<item component="ComponentInfo{com.picsart.studio.light/com.socialin.android.photo.picsinphoto.MainPagerActivity}" drawable="picsart"/>
+
 
 	<!-- PicSay Pro -->
 	<item component="ComponentInfo{com.shinycore.picsaypro/com.shinycore.picsaypro.main}" drawable="picsay"/>
@@ -20302,6 +20365,8 @@
 
 	<!-- Pixel Dungeon -->
 	<item component="ComponentInfo{com.watabou.pixeldungeon/com.watabou.pixeldungeon.PixelDungeon}" drawable="pixeldungeon"/>
+	<item component="ComponentInfo{br.com.rodriformiga.pixeldungeon/com.watabou.pixeldungeon.PixelDungeon}" drawable="pixeldungeon"/>
+
 
 	<!-- Pixel Filter -->
 	<item component="ComponentInfo{screen.dimmer.pixelfilter/screen.dimmer.pixelfilter.MainActivity}" drawable="pixel_filter"/>
@@ -20578,6 +20643,8 @@
 	<item component="ComponentInfo{net.kdt.pojavlaunch/net.kdt.pojavlaunch.PojavLoginActivity}" drawable="pojavlauncher"/>
 	<item component="ComponentInfo{net.kdt.pojavlaunch/net.kdt.pojavlaunch.LauncherActivity}" drawable="pojavlauncher"/>
 	<item component="ComponentInfo{net.kdt.pojavlaunch/net.kdt.pojavlaunch.TestStorageActivity}" drawable="pojavlauncher"/>
+	<item component="ComponentInfo{net.kdt.pojavlaunch.debug/net.kdt.pojavlaunch.TestStorageActivity}" drawable="pojavlauncher"/>
+
 
 	<!-- Poke Genie -->
 	<item component="ComponentInfo{com.cjin.pokegenie.standard/com.canjin.pokegenie.MainActivity}" drawable="pokegenie"/>
@@ -20597,6 +20664,9 @@
 	<!-- Pokémon GO -->
 	<item component="ComponentInfo{com.nianticlabs.pokemongo/com.nianticproject.holoholo.libholoholo.unity.UnityMainActivity}" drawable="pokemon_go"/>
 	<item component="ComponentInfo{com.nianticlabs.pokemongo/com.nianticlabs.platform.launcher.NianticUnityPlayerActivity}" drawable="pokemon_go"/>
+	<item component="ComponentInfo{com.nianticlabs.pokemongo.ares/com.nianticproject.holoholo.libholoholo.unity.UnityMainActivity}" drawable="pokemon_go"/>
+	<item component="ComponentInfo{com.nianticlabs.pokemongo.ares/com.nianticlabs.platform.launcher.NianticUnityPlayerActivity}" drawable="pokemon_go"/>
+
 
 	<!-- Pokémon HOME -->
 	<item component="ComponentInfo{jp.pokemon.pokemonhome/com.unity3d.player.UnityPlayerActivity}" drawable="pokemon_home"/>
@@ -20750,6 +20820,8 @@
 	<item component="ComponentInfo{com.maxmpz.audioplayer/com.maxmpz.audioplayer.rounded_mu}" drawable="poweramp"/>
 	<item component="ComponentInfo{com.maxmpz.audioplayer/com.maxmpz.audioplayer.rounded_inverted_mu}" drawable="poweramp"/>
 	<item component="ComponentInfo{com.maxmpz.audioplayer/com.maxmpz.audioplayer.standard_mu}" drawable="poweramp" />
+	<item component="ComponentInfo{com.maxmpz.audioplayer.huawei/com.maxmpz.audioplayer.standard_adaptive}" drawable="poweramp" />
+
 
 	<!-- Poweramp Equalizer -->
 	<item component="ComponentInfo{com.maxmpz.equalizer/com.maxmpz.equalizer.standard_adaptive}" drawable="poweramp_equalizer"/>
@@ -21165,6 +21237,7 @@
 
 	<!-- qBittorrent Remote -->
 	<item component="ComponentInfo{me.fengmlo.qbRemote/me.fengmlo.qb_remote.MainActivity}" drawable="qbittorrent_remote"/>
+	<item component="ComponentInfo{me.fengmlo.qbRemoteFree/me.fengmlo.qb_remote.MainActivity}" drawable="qbittorrent_remote"/>
 
 	<!-- QCY -->
 	<item component="ComponentInfo{com.qcymall.googleearphonesetup/com.qcymall.earphonesetup.ui.FirstStartActivityV2}" drawable="qcy"/>
@@ -21741,6 +21814,8 @@
 	<item component="ComponentInfo{ee.ioc.phon.android.speak/ee.ioc.phon.android.speak.activity.SpeechActionActivity}" drawable="recorder"/>
 	<item component="ComponentInfo{fr.dzx.audiosource/fr.dzx.audiosource.MainActivity}" drawable="recorder"/>
 	<item component="ComponentInfo{com.android.soundrecorder/com.android.soundrecorder.NewSoundRecorder}" drawable="recorder" />
+	<item component="ComponentInfo{com.hihonor.soundrecorder/com.android.soundrecorder.RecordListActivity}" drawable="recorder" />
+
 
 	<!-- Recurrence -->
 	<item component="ComponentInfo{com.bleyl.recurrence/com.bleyl.recurrence.activities.MainActivity}" drawable="recurrence"/>
@@ -21774,6 +21849,7 @@
 	<item component="ComponentInfo{com.reddit.frontpage/launcher.doge}" drawable="reddit"/>
 	<item component="ComponentInfo{com.reddit.frontpage/launcher.astronaut}" drawable="reddit"/>
 	<item component="ComponentInfo{com.reddit.frontpage/launcher.tothemoon}" drawable="reddit"/>
+	<item component="ComponentInfo{com.rvx.reddit/launcher.default}" drawable="reddit"/>
 
 	<!-- Reddit is fun RIF -->
 	<item component="ComponentInfo{com.andrewshu.android.redditdonation/com.andrewshu.android.reddit.MainActivity}" drawable="reddit_is_fun"/>
@@ -21966,6 +22042,7 @@
 	<!-- RetroArch -->
 	<item component="ComponentInfo{com.retroarch/com.retroarch.browser.mainmenu.MainMenuActivity}" drawable="retroarch"/>
 	<item component="ComponentInfo{com.retroarch.aarch64/com.retroarch.browser.mainmenu.MainMenuActivity}" drawable="retroarch"/>
+	<item component="ComponentInfo{com.retroarch.ra32/com.retroarch.browser.mainmenu.MainMenuActivity}" drawable="retroarch"/>
 
 	<!-- Retrowars -->
 	<item component="ComponentInfo{com.serwylo.retrowars/com.serwylo.retrowars.AndroidLauncher}" drawable="retrowars"/>
@@ -22331,6 +22408,7 @@
 
 	<!-- Saikou -->
 	<item component="ComponentInfo{ani.saikou/ani.saikou.MainActivity}" drawable="saikou"/>
+	<item component="ComponentInfo{dev.tas33n.saikou/ani.saikou.MainActivity}" drawable="saikou"/>
 
 	<!-- Saikou β -->
 	<item component="ComponentInfo{ani.saikou.beta/ani.saikou.MainActivity}" drawable="saikou"/>
@@ -22445,6 +22523,7 @@
 	<!-- Samsung Shop -->
 	<item component="ComponentInfo{com.samsung.ecomm.global.in/com.samsung.ecomm.MainActivity}" drawable="samsung_shop"/>
 	<item component="ComponentInfo{com.samsung.ecomm.global.in/com.samsung.ecomm.global.shop_app.MainActivity}" drawable="samsung_shop"/>
+	<item component="ComponentInfo{com.samsung.ecomm.global.gbr/com.samsung.ecomm.global.shop_app.MainActivity}" drawable="samsung_shop"/>
 
 	<!-- Samsung Smart Camera App -->
 	<item component="ComponentInfo{com.samsungimaging.connectionmanager/com.samsungimaging.connectionmanager.app.cm.Main}" drawable="image_sync"/>
@@ -22574,6 +22653,8 @@
 
 	<!-- SC Mobile -->
 	<item component="ComponentInfo{com.sc.mobilebanking.bd/com.sc.retail.scmobile.MainActivity}" drawable="sc_mobile"/>
+	<item component="ComponentInfo{com.sc.mobilebanking.vn/com.sc.retail.scmobile.MainActivity}" drawable="sc_mobile"/>
+
 
 	<!-- Scalable -->
 	<item component="ComponentInfo{capital.scalable.droid/capital.scalable.droid.redesign.screens.cockpit.CockpitActivity}" drawable="scalable"/>
@@ -23014,6 +23095,8 @@
 	<item component="ComponentInfo{com.nekki.shadowfight/com.nekki.utils.activity.UnityPlayerActivityWithPermissionRequests}" drawable="shadowfight2"/>
 	<item component="ComponentInfo{com.nekki.shadowfight/com.nekki.utils.activity.FCMUnityPlayerActivity}" drawable="shadowfight2"/>
 	<item component="ComponentInfo{com.nekki.shadowfight/com.nekki.utils.activity.FCMNekkiUnityPlayerActivity}" drawable="shadowfight2"/>
+	<item component="ComponentInfo{com.nekki.shadowfight2.paid/com.nekki.utils.activity.UnityPlayerActivityWithPermissionRequests}" drawable="shadowfight2"/>
+
 
 	<!-- Shadow Fight 3 -->
 	<item component="ComponentInfo{com.nekki.shadowfight3/com.nekki.unityplugins.NekkiNativeActivity}" drawable="shadow_fight_3"/>
@@ -24158,6 +24241,7 @@
 	<!-- Skit -->
 	<item component="ComponentInfo{com.pavelrekun.skit/com.pavelrekun.skit.containers.PrimaryContainerActivity}" drawable="skit"/>
 	<item component="ComponentInfo{com.pavelrekun.skit/com.pavelrekun.skit.base.BaseActivity}" drawable="skit"/>
+	<item component="ComponentInfo{com.pavelrekun.skit.premium/com.pavelrekun.skit.base.BaseActivity}}" drawable="skit"/>
 
 	<!-- Skolschema -->
 	<item component="ComponentInfo{com.potatiz.skolschema/com.potatiz.skolschema.MainActivity}" drawable="skolschema"/>
@@ -25063,6 +25147,8 @@
 
 	<!-- Stop Motion Studio -->
 	<item component="ComponentInfo{com.cateater.stopmotionstudio/com.cateater.stopmotionstudio.MainActivity}" drawable="stop_motion_studio"/>
+	<item component="ComponentInfo{com.cateater.stopmotionstudiopro/com.cateater.stopmotionstudio.MainActivity}" drawable="stop_motion_studio"/>
+
 
 	<!-- Storage Saver -->
 	<item component="ComponentInfo{com.samsung.memorysaver/com.samsung.memorysaver.zipunzipapps.ui.activities.ZipLauncherActivity}" drawable="storage_saver"/>
@@ -25108,6 +25194,8 @@
 	<!-- Stremio -->
 	<item component="ComponentInfo{com.stremio.one/com.stremio.MainActivity}" drawable="stremio"/>
 	<item component="ComponentInfo{com.stremio.one/com.stremio.tv.MainActivity}" drawable="stremio"/>
+	<item component="ComponentInfo{com.stremio.beta/com.stremio.MainActivity}" drawable="stremio"/>
+
 
 	<!-- StrengthLog -->
 	<item component="ComponentInfo{com.styrkelabbet.Styrkelabbet/com.styrkelabbet.Styrkelabbet.MainActivity}" drawable="strengthlog"/>
@@ -25241,6 +25329,8 @@
 	<item component="ComponentInfo{com.easybrain.sudoku.android/com.easybrain.template.SplashActivity}" drawable="sudoku"/>
 	<item component="ComponentInfo{com.andoku.three.gp/com.andoku.app.LaunchActivity}" drawable="sudoku"/>
 	<item component="ComponentInfo{com.andoku.two.full/com.andoku.LaunchActivity}" drawable="sudoku"/>
+	<item component="ComponentInfo{easy.sudoku.puzzle.solver.free/com.meevii.ui.activity.SplashActivity}" drawable="sudoku"/>
+
 
 	<!-- SudoQ -->
 	<item component="ComponentInfo{de.sudoq/de.sudoq.controller.menus.SplashActivity}" drawable="sudoq"/>
@@ -25687,6 +25777,7 @@
 
 	<!-- Tapped Out -->
 	<item component="ComponentInfo{com.ea.game.simpsons4_row/com.ea.simpsons.SimpsonsSplashScreen}" drawable="tapped_out"/>
+	<item component="ComponentInfo{com.ea.game.simpsons4_na/com.ea.simpsons.SimpsonsSplashScreen}" drawable="tapped_out"/>
 
 	<!-- TapScanner -->
 	<item component="ComponentInfo{pdf.tap.scanner/pdf.tap.scanner.features.splash.SplashActivity}" drawable="tapscanner"/>
@@ -26366,9 +26457,11 @@
 
 	<!-- The Weather Channel -->
 	<item component="ComponentInfo{com.weather.Weather/com.weather.Weather.app.SplashScreenActivity}" drawable="weathercan"/>
+	<item component="ComponentInfo{com.weather.samsung/com.weather.Weather.app.SplashScreenActivity}" drawable="weathercan"/>
 
 	<!-- The Wolf's Stash -->
 	<item component="ComponentInfo{se.zepiwolf.tws.play/se.zepiwolf.tws.REGULAR}" drawable="the_wolfs_stash"/>
+	<item component="ComponentInfo{se.zepiwolf.tws.web/se.zepiwolf.tws.REGULAR}" drawable="the_wolfs_stash"/>
 
 	<!-- Theme Park -->
 	<item component="ComponentInfo{com.samsung.android.themedesigner/com.samsung.android.themedesigner.SplashActivity}" drawable="theme_park"/>
@@ -26491,6 +26584,8 @@
 
 	<!-- TickTock Video Wallpaper by TikTok -->
 	<item component="ComponentInfo{com.zhiliao.musically.livewallpaper/com.ss.android.ugc.aweme.livewallpaper.ui.MainActivity}" drawable="ticktock_video_wallpaper"/>
+	<item component="ComponentInfo{com.ss.android.ugc.tiktok.livewallpaper/com.ss.android.ugc.aweme.livewallpaper.ui.MainActivity}" drawable="ticktock_video_wallpaper"/>
+
 
 	<!-- TIDAL -->
 	<item component="ComponentInfo{com.aspiro.tidal/com.aspiro.wamp.LoginFragmentActivity}" drawable="tidal"/>
@@ -26581,6 +26676,7 @@
 
 	<!-- TimeR Machine -->
 	<item component="ComponentInfo{io.github.deweyreed.timer.other/io.github.deweyreed.timer.ui.MainActivity}" drawable="timer_machine"/>
+	<item component="ComponentInfo{io.github.deweyreed.timer.google/io.github.deweyreed.timer.ui.MainActivity}" drawable="timer_machine"/>
 
 	<!-- TimeTree -->
 	<item component="ComponentInfo{works.jubilee.timetree/works.jubilee.timetree.ui.SplashActivity}" drawable="timetree"/>
@@ -26906,6 +27002,8 @@
 	<!-- Trail Sense -->
 	<item component="ComponentInfo{com.kylecorry.trail_sense/com.kylecorry.trail_sense.MainActivity}" drawable="trailsense"/>
 	<item component="ComponentInfo{com.kylecorry.trail_sense/com.kylecorry.trail_sense.main.MainActivity}" drawable="trailsense"/>
+	<item component="ComponentInfo{com.kylecorry.trail_sense.dev/com.kylecorry.trail_sense.main.MainActivity}" drawable="trailsense"/>
+
 
 	<!-- Train Timetable Italy -->
 	<item component="ComponentInfo{org.paoloconte.treni_lite/org.paoloconte.orariotreni.app.activities.MainActivity}" drawable="train_timetable_italy"/>
@@ -28272,6 +28370,7 @@
 
 	<!-- Vivo.com -->
 	<item component="ComponentInfo{com.vivo.website/com.vivo.website.activity.SplashActivity}" drawable="vivocom"/>
+	<item component="ComponentInfo{com.vivo.website.gdpr/com.vivo.website.activity.SplashActivity}" drawable="vivocom"/>
 
 	<!-- VK -->
 	<item component="ComponentInfo{com.vkontakte.android/com.vkontakte.android.MainActivity}" drawable="vk"/>
@@ -28722,6 +28821,7 @@
 	<item component="ComponentInfo{com.walmart.android/com.walmart.glass.integration.splash.SplashActivity}" drawable="walmart"/>
 	<item component="ComponentInfo{com.walmart.beta/com.walmart.glass.integration.splash.SplashActivity}" drawable="walmart"/>
 	<item component="ComponentInfo{com.walmart.grocery/com.walmart.grocery.screen.start.StartupActivity}" drawable="walmart"/>
+	<item component="ComponentInfo{com.walmart.mg/com.walmart.glass.integration.splash.SplashActivity}" drawable="walmart"/>
 
 	<!-- Walpy -->
 	<item component="ComponentInfo{com.feresr.walpy/com.feresr.walpy.welcome.WelcomeActivity}" drawable="walpy"/>
@@ -29813,6 +29913,7 @@
 
 	<!-- YouTube -->
 	<item component="ComponentInfo{com.google.android.youtube/com.google.android.youtube.app.honeycomb.Shell$HomeActivity}" drawable="youtube"/>
+	<item component="ComponentInfo{app.rex.android.youtube/com.google.android.youtube.app.honeycomb.Shell$HomeActivity}" drawable="youtube"/>
 
 	<!-- YouTube Downloader -->
 	<item component="ComponentInfo{dentex.youtube.downloader/dentex.youtube.downloader._MainActivity}" drawable="youtube_downloader"/>


### PR DESCRIPTION
Made a new script which looks for doubles in activity names between appfilter.xml and requests.txt (props to ChatGPT for being patient with me), which runs only 17 seconds and also outputs the names of the entries at glance, so one doesn't have to look up the names anymore.

Added doubles (same app name, different package name, same activity name) and country variants. Didn't add variants like "pro", "beta", "HD" etc., for they have sometimes different icons.
