### PR TITLE
appfilter.xml: Add "Gadgetbridge Nightly" and "Gadgetbridge Nightly No Pebble"

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -10728,6 +10728,12 @@
 	<item component="ComponentInfo{nodomain.freeyourgadget.gadgetbridge/nodomain.freeyourgadget.gadgetbridge.activities.ControlCenter}" drawable="gadgetbridge"/>
 	<item component="ComponentInfo{nodomain.freeyourgadget.gadgetbridge/nodomain.freeyourgadget.gadgetbridge.activities.ControlCenterv2}" drawable="gadgetbridge"/>
 
+	<!-- Gadgetbridge Nightly -->
+	<item component="ComponentInfo{nodomain.freeyourgadget.gadgetbridge.nightly/nodomain.freeyourgadget.gadgetbridge.activities.ControlCenterv2}" drawable="gadgetbridge"/>
+
+	<!-- Gadgetbridge Nightly No Pebble -->
+	<item component="ComponentInfo{nodomain.freeyourgadget.gadgetbridge.nightly_nopebble/nodomain.freeyourgadget.gadgetbridge.activities.ControlCenterv2}" drawable="gadgetbridge"/>
+
 	<!-- Gaia GPS -->
 	<item component="ComponentInfo{com.trailbehind.android.gaiagps.pro/com.trailbehind.activities.MainActivity}" drawable="gaia_gps"/>
 


### PR DESCRIPTION
Note that the original icon is the same for both "Gadgetbridge" and "Gadgetbridge Nightly," the only thing that differs is the coloring.

---

Gadgetbridge:
<img src="https://f-droid.org/repo/nodomain.freeyourgadget.gadgetbridge/en-US/icon_X8EVBNWmEaTA1EERH5xgBoSpAan8BNTrrDa4Osj-Da8=.png" width="200" height="200">

Gadgetbridge Nightly:
<img src="https://freeyourgadget.codeberg.page/fdroid/repo/nodomain.freeyourgadget.gadgetbridge.nightly/en-US/icon_i_BlewW81CYgyIgiPAAKtagv_Wxscfiw_Ntbn9AeilY=.png" width="200" height="200">
