### PR TITLE
appfilter.xml: Update 'Fossify' apps

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -9724,90 +9724,6 @@
 	<!-- FOSS Warn -->
 	<item component="ComponentInfo{de.nucleus.foss_warn/de.nucleus.foss_warn.MainActivity}" drawable="foss_warn"/>
 
-	<!-- Fossify App Launcher -->
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Pink}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Purple}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Deep_purple}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Indigo}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Blue}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Light_blue}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Cyan}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Teal}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Green}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Light_green}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Lime}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Yellow}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Amber}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Orange}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Deep_orange}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Brown}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Blue_grey}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Grey_black}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher/org.fossify.applauncher.activities.SplashActivity.Red}" drawable="simpleapplauncher"/>
-
-	<!-- Fossify App Launcher Pro -->
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Pink}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Purple}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Deep_purple}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Indigo}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Blue}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Light_blue}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Cyan}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Teal}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Green}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Light_green}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Lime}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Yellow}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Amber}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Orange}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Deep_orange}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Brown}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Blue_grey}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Grey_black}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{org.fossify.applauncher.pro/org.fossify.applauncher.pro.activities.SplashActivity.Red}" drawable="simpleapplauncher"/>
-
-	<!-- Fossify Calculator -->
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Pink}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Purple}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Deep_purple}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Indigo}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Blue}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Light_blue}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Cyan}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Teal}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Green}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Light_green}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Lime}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Yellow}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Amber}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Orange}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Deep_orange}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Brown}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Blue_grey}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Grey_black}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculator/org.fossify.calculator.activities.SplashActivity.Red}" drawable="calculator"/>
-
-	<!-- Fossify Calculator Pro -->
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Pink}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Purple}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Deep_purple}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Indigo}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Blue}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Light_blue}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Cyan}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Teal}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Green}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Light_green}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Lime}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Yellow}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Amber}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Orange}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Deep_orange}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Brown}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Blue_grey}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Grey_black}" drawable="calculator"/>
-	<item component="ComponentInfo{org.fossify.calculcator.pro/org.fossify.calculcator.pro.activities.SplashActivity.Red}" drawable="calculator"/>
-
 	<!-- Fossify Calendar -->
 	<item component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Pink}" drawable="simple_calendar"/>
 	<item component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Purple}" drawable="simple_calendar"/>
@@ -9830,150 +9746,25 @@
 	<item component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Red}" drawable="simple_calendar"/>
 
 	<!-- Fossify Calendar Dynamic icon -->
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Pink}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Purple}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Deep_purple}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Indigo}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Blue}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Light_blue}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Cyan}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Teal}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Green}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Light_green}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Lime}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Yellow}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Amber}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Orange}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Deep_orange}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Brown}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Blue_grey}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Grey_black}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Red}" prefix="calendar_simple_"/>
-
-	<!-- Fossify Calendar Pro -->
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Pink}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Purple}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Deep_purple}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Indigo}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Blue}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Light_blue}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Cyan}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Teal}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Green}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Light_green}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Lime}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Yellow}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Amber}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Orange}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Deep_orange}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Brown}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Blue_grey}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Grey_black}" drawable="simple_calendar"/>
-	<item component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Red}" drawable="simple_calendar"/>
-
-	<!-- Fossify Calendar Pro Dynamic icon -->
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Pink}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Purple}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Deep_purple}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Indigo}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Blue}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Light_blue}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Cyan}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Teal}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Green}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Light_green}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Lime}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Yellow}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Amber}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Orange}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Deep_orange}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Brown}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Blue_grey}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Grey_black}" prefix="calendar_simple_"/>
-  <calendar component="ComponentInfo{org.fossify.calendar.pro/org.fossify.calendar.pro.activities.SplashActivity.Red}" prefix="calendar_simple_"/>
-
-	<!-- Fossify Camera -->
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Pink}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Purple}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Deep_purple}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Indigo}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Blue}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Light_blue}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Cyan}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Teal}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Green}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Light_green}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Lime}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Yellow}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Amber}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Orange}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Deep_orange}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Brown}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Blue_grey}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Grey_black}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera/org.fossify.camera.activities.SplashActivity.Red}" drawable="simplecamera"/>
-
-	<!-- Fossify Camera Pro -->
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Pink}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Purple}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Deep_purple}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Indigo}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Blue}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Light_blue}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Cyan}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Teal}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Green}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Light_green}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Lime}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Yellow}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Amber}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Orange}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Deep_orange}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Brown}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Blue_grey}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Grey_black}" drawable="simplecamera"/>
-	<item component="ComponentInfo{org.fossify.camera.pro/org.fossify.camera.pro.activities.SplashActivity.Red}" drawable="simplecamera"/>
-
-	<!-- Fossify Clock -->
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Pink}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Purple}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Deep_purple}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Indigo}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Blue}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Light_blue}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Cyan}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Teal}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Green}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Light_green}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Lime}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Yellow}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Amber}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Orange}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Deep_orange}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Brown}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Blue_grey}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Grey_black}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock/org.fossify.clock.activities.SplashActivity.Red}" drawable="clock"/>
-
-	<!-- Fossify Clock Pro -->
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Pink}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Purple}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Deep_purple}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Indigo}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Blue}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Light_blue}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Cyan}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Teal}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Green}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Light_green}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Lime}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Yellow}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Amber}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Orange}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Deep_orange}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Brown}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Blue_grey}" drawable="clock"/>
-	<item component="ComponentInfo{org.fossify.clock.pro/org.fossify.clock.pro.activities.SplashActivity.Grey_black}" drawable="clock"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Pink}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Purple}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Deep_purple}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Indigo}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Blue}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Light_blue}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Cyan}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Teal}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Green}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Light_green}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Lime}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Yellow}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Amber}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Orange}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Deep_orange}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Brown}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Blue_grey}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Grey_black}" prefix="calendar_simple_"/>
+	<calendar component="ComponentInfo{org.fossify.calendar/org.fossify.calendar.activities.SplashActivity.Red}" prefix="calendar_simple_"/>
 
 	<!-- Fossify Contacts -->
 	<item component="ComponentInfo{org.fossify.contacts/org.fossify.contacts.activities.SplashActivity.Pink}" drawable="contacts"/>
@@ -9996,47 +9787,26 @@
 	<item component="ComponentInfo{org.fossify.contacts/org.fossify.contacts.activities.SplashActivity.Grey_black}" drawable="contacts"/>
 	<item component="ComponentInfo{org.fossify.contacts/org.fossify.contacts.activities.SplashActivity.Red}" drawable="contacts"/>
 
-	<!-- Fossify Contacts Pro -->
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Pink}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Purple}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Deep_purple}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Indigo}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Blue}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Light_blue}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Cyan}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Teal}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Green}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Light_green}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Lime}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Yellow}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Amber}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Orange}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Deep_orange}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Brown}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Blue_grey}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Grey_black}" drawable="contacts"/>
-	<item component="ComponentInfo{org.fossify.contacts.pro/org.fossify.contacts.pro.activities.SplashActivity.Red}" drawable="contacts"/>
-
-	<!-- Fossify Dialer -->
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Pink}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Purple}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Deep_purple}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Indigo}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Blue}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Light_blue}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Cyan}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Teal}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Green}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Light_green}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Lime}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Yellow}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Amber}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Orange}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Deep_orange}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Brown}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Blue_grey}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Grey_black}" drawable="phone"/>
-	<item component="ComponentInfo{org.fossify.dialer/org.fossify.dialer.activities.SplashActivity.Red}" drawable="phone"/>
+	<!-- Fossify Phone -->
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Pink}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Purple}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Deep_purple}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Indigo}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Blue}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Light_blue}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Cyan}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Teal}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Green}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Light_green}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Lime}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Yellow}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Amber}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Orange}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Deep_orange}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Brown}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Blue_grey}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Grey_black}" drawable="phone"/>
+	<item component="ComponentInfo{org.fossify.phone/org.fossify.phone.activities.SplashActivity.Red}" drawable="phone"/>
 
 	<!-- Fossify Draw -->
 	<item component="ComponentInfo{org.fossify.draw/org.fossify.draw.activities.SplashActivity.Pink}" drawable="simpledraw"/>
@@ -10059,27 +9829,6 @@
 	<item component="ComponentInfo{org.fossify.draw/org.fossify.draw.activities.SplashActivity.Grey_black}" drawable="simpledraw"/>
 	<item component="ComponentInfo{org.fossify.draw/org.fossify.draw.activities.SplashActivity.Red}" drawable="simpledraw"/>
 
-	<!-- Fossify Draw Pro -->
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Pink}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Purple}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Deep_purple}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Indigo}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Blue}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Light_blue}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Cyan}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Teal}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Green}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Light_green}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Lime}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Yellow}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Amber}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Orange}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Deep_orange}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Brown}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Blue_grey}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Grey_black}" drawable="simpledraw"/>
-	<item component="ComponentInfo{org.fossify.draw.pro/org.fossify.draw.pro.activities.SplashActivity.Red}" drawable="simpledraw"/>
-
 	<!-- Fossify File Manager -->
 	<item component="ComponentInfo{org.fossify.filemanager/org.fossify.filemanager.activities.SplashActivity.Pink}" drawable="simplefilemanager"/>
 	<item component="ComponentInfo{org.fossify.filemanager/org.fossify.filemanager.activities.SplashActivity.Purple}" drawable="simplefilemanager"/>
@@ -10100,69 +9849,6 @@
 	<item component="ComponentInfo{org.fossify.filemanager/org.fossify.filemanager.activities.SplashActivity.Blue_grey}" drawable="simplefilemanager"/>
 	<item component="ComponentInfo{org.fossify.filemanager/org.fossify.filemanager.activities.SplashActivity.Grey_black}" drawable="simplefilemanager"/>
 	<item component="ComponentInfo{org.fossify.filemanager/org.fossify.filemanager.activities.SplashActivity.Red}" drawable="simplefilemanager"/>
-
-	<!-- Fossify File Manager Pro -->
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Pink}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Purple}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Deep_purple}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Indigo}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Blue}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Light_blue}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Cyan}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Teal}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Green}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Light_green}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Lime}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Yellow}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Amber}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Orange}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Deep_orange}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Brown}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Blue_grey}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Grey_black}" drawable="simplefilemanager"/>
-	<item component="ComponentInfo{org.fossify.filemanager.pro/org.fossify.filemanager.pro.activities.SplashActivity.Red}" drawable="simplefilemanager"/>
-
-	<!-- Fossify Flashlight -->
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Pink}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Purple}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Deep_purple}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Indigo}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Blue}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Light_blue}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Cyan}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Teal}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Green}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Light_green}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Lime}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Yellow}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Amber}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Orange}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Deep_orange}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Brown}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Blue_grey}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Grey_black}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight/org.fossify.flashlight.activities.SplashActivity.Red}" drawable="simpleflashlight"/>
-
-	<!-- Fossify Flashlight Pro -->
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Pink}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Purple}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Deep_purple}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Indigo}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Blue}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Light_blue}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Cyan}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Teal}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Green}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Light_green}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Lime}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Yellow}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Amber}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Orange}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Deep_orange}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Brown}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Blue_grey}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Grey_black}" drawable="simpleflashlight"/>
-	<item component="ComponentInfo{org.fossify.flashlight.pro/org.fossify.flashlight.pro.activities.SplashActivity.Red}" drawable="simpleflashlight"/>
 
 	<!-- Fossify Gallery -->
 	<item component="ComponentInfo{org.fossify.gallery/org.fossify.gallery.activities.SplashActivity.Pink}" drawable="simplegallery"/>
@@ -10185,27 +9871,6 @@
 	<item component="ComponentInfo{org.fossify.gallery/org.fossify.gallery.activities.SplashActivity.Grey_black}" drawable="simplegallery"/>
 	<item component="ComponentInfo{org.fossify.gallery/org.fossify.gallery.activities.SplashActivity.Red}" drawable="simplegallery"/>
 
-	<!-- Fossify Gallery Pro -->
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Pink}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Purple}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Deep_purple}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Indigo}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Blue}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Light_blue}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Cyan}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Teal}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Green}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Light_green}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Lime}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Yellow}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Amber}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Orange}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Deep_orange}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Brown}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Blue_grey}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Grey_black}" drawable="simplegallery"/>
-	<item component="ComponentInfo{org.fossify.gallery.pro/org.fossify.gallery.pro.activities.SplashActivity.Red}" drawable="simplegallery"/>
-
 	<!-- Fossify Keyboard -->
 	<item component="ComponentInfo{org.fossify.keyboard/org.fossify.keyboard.activities.SplashActivity.Grey_black}" drawable="simple_keyboard"/>
 	<item component="ComponentInfo{org.fossify.keyboard/org.fossify.keyboard.activities.SplashActivity.Pink}" drawable="simple_keyboard"/>
@@ -10225,27 +9890,6 @@
 	<item component="ComponentInfo{org.fossify.keyboard/org.fossify.keyboard.activities.SplashActivity.Brown}" drawable="simple_keyboard"/>
 	<item component="ComponentInfo{org.fossify.keyboard/org.fossify.keyboard.activities.SplashActivity.Blue_grey}" drawable="simple_keyboard"/>
 	<item component="ComponentInfo{org.fossify.keyboard/org.fossify.keyboard.activities.SplashActivity.Red}" drawable="simple_keyboard"/>
-
-	<!-- Fossify Launcher -->
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Pink}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Purple}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Deep_purple}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Indigo}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Blue}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Light_blue}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Cyan}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Teal}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Green}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Light_green}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Lime}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Yellow}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Amber}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Orange}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Deep_orange}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Brown}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Blue_grey}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Grey_black}" drawable="simplelauncher"/>
-	<item component="ComponentInfo{org.fossify.launcher/org.fossify.launcher.activities.SplashActivity.Red}" drawable="simplelauncher"/>
 
 	<!-- Fossify Music Player -->
 	<item component="ComponentInfo{org.fossify.musicplayer/org.fossify.musicplayer.activities.SplashActivity.Pink}" drawable="simplemusicplayer"/>
@@ -10268,27 +9912,6 @@
 	<item component="ComponentInfo{org.fossify.musicplayer/org.fossify.musicplayer.activities.SplashActivity.Grey_black}" drawable="simplemusicplayer"/>
 	<item component="ComponentInfo{org.fossify.musicplayer/org.fossify.musicplayer.activities.SplashActivity.Red}" drawable="simplemusicplayer"/>
 
-	<!-- Fossify Music Player Pro -->
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Pink}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Purple}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Deep_purple}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Indigo}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Blue}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Light_blue}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Cyan}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Teal}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Green}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Light_green}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Lime}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Yellow}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Amber}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Orange}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Deep_orange}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Brown}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Blue_grey}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Grey_black}" drawable="simplemusicplayer"/>
-	<item component="ComponentInfo{org.fossify.musicplayer.pro/org.fossify.musicplayer.pro.activities.SplashActivity.Red}" drawable="simplemusicplayer"/>
-
 	<!-- Fossify Notes -->
 	<item component="ComponentInfo{org.fossify.notes/org.fossify.notes.activities.SplashActivity.Pink}" drawable="simplenotes"/>
 	<item component="ComponentInfo{org.fossify.notes/org.fossify.notes.activities.SplashActivity.Purple}" drawable="simplenotes"/>
@@ -10310,46 +9933,25 @@
 	<item component="ComponentInfo{org.fossify.notes/org.fossify.notes.activities.SplashActivity.Grey_black}" drawable="simplenotes"/>
 	<item component="ComponentInfo{org.fossify.notes/org.fossify.notes.activities.SplashActivity.Red}" drawable="simplenotes"/>
 
-	<!-- Fossify Notes Pro -->
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Pink}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Purple}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Deep_purple}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Indigo}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Blue}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Light_blue}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Cyan}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Teal}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Green}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Light_green}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Lime}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Yellow}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Amber}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Orange}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Deep_orange}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Brown}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Blue_grey}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Grey_black}" drawable="simplenotes"/>
-	<item component="ComponentInfo{org.fossify.notes.pro/org.fossify.notes.pro.activities.SplashActivity.Red}" drawable="simplenotes"/>
-
-	<!-- Fossify SMS Messenger -->
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Grey_black}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Pink}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Purple}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Deep_purple}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Indigo}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Blue}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Light_blue}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Cyan}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Teal}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Green}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Light_green}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Lime}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Yellow}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Orange}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Deep_orange}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Brown}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Blue_grey}" drawable="messages"/>
-	<item component="ComponentInfo{org.fossify.smsmessenger/org.fossify.smsmessenger.activities.SplashActivity.Red}" drawable="messages"/>
+	<!-- Fossify Messages -->
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Grey_black}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Pink}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Purple}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Deep_purple}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Indigo}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Blue}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Light_blue}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Cyan}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Teal}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Green}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Light_green}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Lime}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Yellow}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Orange}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Deep_orange}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Brown}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Blue_grey}" drawable="messages"/>
+	<item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Red}" drawable="messages"/>
 
 	<!-- Fossify Thank You -->
 	<item component="ComponentInfo{org.fossify.thankyou/org.fossify.thankyou.activities.SplashActivity.Pink}" drawable="simplethankyou"/>
@@ -10392,27 +9994,6 @@
 	<item component="ComponentInfo{org.fossify.voicerecorder/org.fossify.voicerecorder.activities.SplashActivity.Blue_grey}" drawable="recorder"/>
 	<item component="ComponentInfo{org.fossify.voicerecorder/org.fossify.voicerecorder.activities.SplashActivity.Grey_black}" drawable="recorder"/>
 	<item component="ComponentInfo{org.fossify.voicerecorder/org.fossify.voicerecorder.activities.SplashActivity.Red}" drawable="recorder"/>
-
-	<!-- Fossify Voicerecorder Pro -->
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Pink}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Purple}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Deep_purple}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Indigo}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Blue}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Light_blue}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Cyan}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Teal}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Green}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Light_green}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Lime}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Yellow}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Amber}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Orange}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Deep_orange}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Brown}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Blue_grey}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Grey_black}" drawable="recorder"/>
-	<item component="ComponentInfo{org.fossify.voicerecorder.pro/org.fossify.voicerecorder.pro.activities.SplashActivity.Red}" drawable="recorder"/>
 
 	<!-- Fossil Hybrid -->
 	<item component="ComponentInfo{com.fossil.wearables.fossil/com.portfolio.platform.uirenew.splash.SplashScreenActivity}" drawable="fossilhybrid"/>


### PR DESCRIPTION
Note: [SimpleMobileTools](https://github.com/SimpleMobileTools) applications have been fork by [Fossify](https://github.com/FossifyOrg). Find the reasons for the fork [here](https://github.com/SimpleMobileTools/General-Discussion/issues/241).

---

This pull request partially reverses and updates commit:  182e6ea442fee61f61d1fd478776de42409cc84d

- Removed all 'pro' versions: SimpleMobileTools used to distribute apps as a free version on f-droid and the 'pro' version on the PlayStore for a fee. Fossify does not provide 'pro' versions and releases the same apps on both f-droid and PlayStore.
- Fixed the identifier for the 'Dialer' (now 'Phone') and 'Messanger' (now 'Messages') apps (already released apps by fossify)
- Kept entries for 'Draw', 'Keyboard', 'Draw', 'Keyboard', 'Music Player' , 'Notes', 'Thank You' and 'Voice Recorder' apps (fossify apps NOT yet released but already rebranded)
- Removed entries for 'App Launcher', 'Calculator', 'Camera', 'Clock' and 'Flashlight' (fossify apps NOT yet released and NOT yet rebranded)

This pull request superseed my previus #1961


@Donnnno, if changes are needed let me know.


