### PR TITLE
Move the creation of the drawable.xml to Android studio

### DIFF
--- a/other/scripts/preparerelease.py
+++ b/other/scripts/preparerelease.py
@@ -111,6 +111,9 @@ def create_new_drawables(svgdir: str,newdrawables:str) -> None:
             fp.write(f'{drawable_pre}{drawable}{drawable_suf}')
         fp.write('</resources>\n')
         fp.close
+        
+    newIcons= len(newDrawables)   
+    print("There are %i new icons"% newIcons)
 
 #new appfilter sort
 def sortxml(path:str):

--- a/other/scripts/preparerelease.py
+++ b/other/scripts/preparerelease.py
@@ -98,7 +98,7 @@ def create_new_drawables(svgdir: str,newdrawables:str) -> None:
             for line in lines:
                 new = re.search(drawable, line)
                 if new:
-                    newDrawables.add(new.group(0)[0])
+                    newDrawables.add(new.group(1))
     print(newDrawables)
     for file_path in glob.glob(f"{svgdir}/*.svg"):
         file = os.path.basename(file_path)

--- a/other/scripts/preparerelease.py
+++ b/other/scripts/preparerelease.py
@@ -1,17 +1,11 @@
-from pathlib import Path
 import re
 import glob
 from shutil import copy2
 from typing import List
 import argparse
-import pathlib
 from lxml import etree
 import os
 import cairosvg
-
-
-import argparse
-import os
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--checkonly", action="store_true", help="Run checks only")
@@ -117,117 +111,6 @@ def create_new_drawables(svgdir: str,newdrawables:str) -> None:
             fp.write(f'{drawable_pre}{drawable}{drawable_suf}')
         fp.write('</resources>\n')
         fp.close
-
-def merge_new_drawables(pathxml: str, pathnewxml:str, assetpath:str, iconsdir:str, xmldir: str, assetsdir:str,appfilterpath:str):
-
-    drawables = []
-    folder = []
-    calendar = []
-    google = []
-    microsoft = []
-    emoji = []
-    numbers = []
-    symbols = []
-    number = []
-    drawable = re.compile(r'drawable="([\w_]+)"')
-    
-    # Get all in New
-    newDrawables = []
-    with open(pathnewxml) as file:
-        lines = file.readlines()
-        for line in lines:
-            new = re.search(drawable,line)
-            if new:
-                newDrawables.append(new.groups(0)[0])
-    newDrawables.sort()
-
-    # collect existing drawables
-    for dir_ in sorted(Path(iconsdir).glob('*.svg'), key=natural_sort_key):
-        file_ = dir_.name
-        new = file_[:file_.rindex('.')]
-        if not new in newDrawables:
-            if new.startswith('folder_'):
-                folder.append(new)
-            elif new.startswith('calendar_'):
-                calendar.append(new)
-            elif new.startswith('google_'):
-                google.append(new)
-            elif new.startswith('microsoft_') or new.startswith('xbox'):
-                microsoft.append(new)
-            elif new.startswith('emoji_'):
-                emoji.append(new)
-            elif new.startswith('letter_') or new.startswith('number_') or new.startswith('currency_') or new.startswith('symbol_'):
-                symbols.append(new)
-            elif new.startswith('_'):
-                number.append(new)
-            else:
-                drawables.append(new)
-
-    newIcons= len(newDrawables)
-    print("There are %i new icons"% newIcons)
-    # remove duplicates and sort
-    drawables = list(set(drawables))
-    drawables.sort()
-    folder = list(set(folder))
-    folder.sort()
-    calendar = list(set(calendar))
-    calendar.sort()
-    google = list(set(google))
-    google.sort()
-    microsoft = list(set(microsoft))
-    microsoft.sort()
-    emoji = list(set(emoji))
-    emoji.sort()
-    
-    # build
-    output = '<?xml version="1.0" encoding="utf-8"?>\n<resources>\n<version>1</version>\n\n\t<category title="New" />\n\t'
-    for newDrawable in newDrawables:
-        output += '<item drawable="%s" />\n\t' % newDrawable
-
-    output += '\n\t<category title="Folders" />\n\t'
-    for entry in folder:
-        output += '<item drawable="%s" />\n\t' % entry
-
-    output += '\n\t<category title="Calendar" />\n\t'
-    for entry in calendar:
-        output += '<item drawable="%s" />\n\t' % entry
-
-    output += '\n\t<category title="Google" />\n\t'
-    for entry in google:
-        output += '<item drawable="%s" />\n\t' % entry
-    
-    output += '\n\t<category title="Microsoft" />\n\t'
-    for entry in microsoft:
-        output += '<item drawable="%s" />\n\t' % entry
-
-    output += '\n\t<category title="Symbols" />\n\t'
-    for entry in symbols:
-        output += '<item drawable="%s" />\n\t' % entry
-    output += '\n\t<category title="Numbers" />\n\t'
-    for entry in numbers:
-        output += '<item drawable="%s" />\n\t' % entry
-    output += '\n\t<category title="0-9" />\n\t'
-    for entry in number:
-        output += '<item drawable="%s" />\n\t' % entry
-
-    output += '\n\t<category title="A" />\n\t'
-    letter = "a"
-
-    # iterate alphabet
-    for entry in drawables:
-        if not entry.startswith(letter):
-            letter = chr(ord(letter) + 1)
-            output += '\n\t<category title="%s" />\n\t' % letter.upper()
-        output += '<item drawable="%s" />\n\t' % entry
-    output += "\n</resources>"
-
-    # write to new_'filename'.xml in working directory
-    outFile = open(pathxml, "w", encoding='utf-8')
-    outFile.write(output)
-    copy2(pathxml, assetpath)
-    copy2(appfilterpath, assetsdir)
-    copy2(appfilterpath, xmldir)
-    os.remove(pathnewxml)
 
 #new appfilter sort
 def sortxml(path:str):
@@ -510,7 +393,6 @@ def main():
     create_icons(SIZES, OTHER_PATH ,EXPORT_LIGHT_DIR, BLACK_DIR, 'Light Mode')
     remove_svg(OTHER_PATH)
     sortxml(APPFILTER_PATH) 
-    #merge_new_drawables(DRAWABLE_PATH,NEWDRAWABLE_PATH,ASSETS_PATH,WHITE_DIR, RES_XML_PATH,ASSETS_PATH,APPFILTER_PATH)
 
 if __name__ == "__main__":
 	main()

--- a/other/scripts/preparerelease.py
+++ b/other/scripts/preparerelease.py
@@ -93,12 +93,12 @@ def create_new_drawables(svgdir: str,newdrawables:str) -> None:
                 new = re.search(drawable, line)
                 if new:
                     newDrawables.add(new.group(1))
-    print(newDrawables)
+
     for file_path in glob.glob(f"{svgdir}/*.svg"):
         file = os.path.basename(file_path)
         name = file[:-4]
         newDrawables.add(name)
-    print(newDrawables)
+
     sortedNewDrawables = sorted(newDrawables)
 
     drawable_pre = '\t<item drawable="'
@@ -111,7 +111,7 @@ def create_new_drawables(svgdir: str,newdrawables:str) -> None:
             fp.write(f'{drawable_pre}{drawable}{drawable_suf}')
         fp.write('</resources>\n')
         fp.close
-        
+
     newIcons= len(newDrawables)   
     print("There are %i new icons"% newIcons)
 

--- a/other/scripts/preparerelease.py
+++ b/other/scripts/preparerelease.py
@@ -98,7 +98,7 @@ def create_new_drawables(svgdir: str,newdrawables:str) -> None:
             for line in lines:
                 new = re.search(drawable, line)
                 if new:
-                    newDrawables.add(new.group(0))
+                    newDrawables.add(new.group(0)[0])
     print(newDrawables)
     for file_path in glob.glob(f"{svgdir}/*.svg"):
         file = os.path.basename(file_path)

--- a/other/scripts/preparerelease.py
+++ b/other/scripts/preparerelease.py
@@ -15,6 +15,7 @@ import os
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--checkonly", action="store_true", help="Run checks only")
+parser.add_argument("--new", action="store_true", help="Run a new Release")
 parser.add_argument('ARCTICONS_DIR', type=str, help='Path to the Arcticons directory')
 
 args = parser.parse_args()
@@ -86,16 +87,34 @@ def natural_sort_key(s: str, _nsre=re.compile('([0-9]+)')):
 
 
 def create_new_drawables(svgdir: str,newdrawables:str) -> None:
+
+    drawable = re.compile(r'drawable="([\w_]+)"')
+    
+    # Get all in New
+    newDrawables = set()
+    if not args.new:
+        with open(newdrawables) as file:
+            lines = file.readlines()
+            for line in lines:
+                new = re.search(drawable, line)
+                if new:
+                    newDrawables.add(new.group(0))
+
+    for file_path in glob.glob(f"{svgdir}/*.svg"):
+        file = os.path.basename(file_path)
+        name = file[:-4]
+        newDrawables.add(name)
+
+    sortedNewDrawables = sorted(newDrawables)
+
     drawable_pre = '\t<item drawable="'
     drawable_suf = '" />\n'
     if os.path.exists(newdrawables):
         os.remove(newdrawables)
     with open(newdrawables, 'w',encoding="utf-8") as fp:
         fp.write('<?xml version="1.0" encoding="utf-8"?>\n<resources>\n\t<version>1</version>\n\t<category title="New" />\n')
-        for file_path in glob.glob(f"{svgdir}/*.svg"):
-            file= os.path.basename(file_path)
-            name = file[:-4]
-            fp.write(f'{drawable_pre}{name}{drawable_suf}')
+        for drawable in newDrawables:
+            fp.write(f'{drawable_pre}{drawable}{drawable_suf}')
         fp.write('</resources>\n')
         fp.close
 

--- a/other/scripts/preparerelease.py
+++ b/other/scripts/preparerelease.py
@@ -491,7 +491,7 @@ def main():
     create_icons(SIZES, OTHER_PATH ,EXPORT_LIGHT_DIR, BLACK_DIR, 'Light Mode')
     remove_svg(OTHER_PATH)
     sortxml(APPFILTER_PATH) 
-    merge_new_drawables(DRAWABLE_PATH,NEWDRAWABLE_PATH,ASSETS_PATH,WHITE_DIR, RES_XML_PATH,ASSETS_PATH,APPFILTER_PATH)
+    #merge_new_drawables(DRAWABLE_PATH,NEWDRAWABLE_PATH,ASSETS_PATH,WHITE_DIR, RES_XML_PATH,ASSETS_PATH,APPFILTER_PATH)
 
 if __name__ == "__main__":
 	main()

--- a/other/scripts/preparerelease.py
+++ b/other/scripts/preparerelease.py
@@ -99,12 +99,12 @@ def create_new_drawables(svgdir: str,newdrawables:str) -> None:
                 new = re.search(drawable, line)
                 if new:
                     newDrawables.add(new.group(0))
-
+    print(newDrawables)
     for file_path in glob.glob(f"{svgdir}/*.svg"):
         file = os.path.basename(file_path)
         name = file[:-4]
         newDrawables.add(name)
-
+    print(newDrawables)
     sortedNewDrawables = sorted(newDrawables)
 
     drawable_pre = '\t<item drawable="'
@@ -113,7 +113,7 @@ def create_new_drawables(svgdir: str,newdrawables:str) -> None:
         os.remove(newdrawables)
     with open(newdrawables, 'w',encoding="utf-8") as fp:
         fp.write('<?xml version="1.0" encoding="utf-8"?>\n<resources>\n\t<version>1</version>\n\t<category title="New" />\n')
-        for drawable in newDrawables:
+        for drawable in sortedNewDrawables:
             fp.write(f'{drawable_pre}{drawable}{drawable_suf}')
         fp.write('</resources>\n')
         fp.close

--- a/preparehelper/src/main/java/com/donnnno/arcticons/helper/Start.java
+++ b/preparehelper/src/main/java/com/donnnno/arcticons/helper/Start.java
@@ -71,6 +71,7 @@ public class Start {
 
         try {
             XMLCreator.mergeNewDrawables(xmlDir+"/drawable.xml",newXML,assetsDir,sourceDir,xmlDir,appFilter);
+            System.out.println("XML task completed");
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/preparehelper/src/main/java/com/donnnno/arcticons/helper/Start.java
+++ b/preparehelper/src/main/java/com/donnnno/arcticons/helper/Start.java
@@ -18,6 +18,10 @@ public class Start {
         String sourceDir = rootDir + "/icons/white";
         String resDir;
         String destDir;
+        String xmlDir;
+        String newXML;
+        String assetsDir;
+        String appFilter;
         System.out.println("root Dir: " + rootPath);
         System.out.println("root Dir Name: " + rootDirName);
         if (args.length > 0) {
@@ -57,12 +61,19 @@ public class Start {
             }
             System.out.println("SvgToVector task completed");
             // Read appfilter xml and create icon, drawable xml file.
-                /* try {
-            ConfigProcessor.loadAndCreateConfigs(appFilterFile, resDir);
+
+
+            xmlDir =rootDir+"/app/src/main/res/xml";
+            newXML = rootDir+"/other/newdrawables.xml";
+            assetsDir = rootDir + "/app/src/main/assets";
+            appFilter = rootDir + "/other/appfilter.xml";
+
+
+        try {
+            XMLCreator.mergeNewDrawables(xmlDir+"/drawable.xml",newXML,assetsDir,sourceDir,xmlDir,appFilter);
         } catch (Exception e) {
             e.printStackTrace();
         }
-        */
         }
     }
 }

--- a/preparehelper/src/main/java/com/donnnno/arcticons/helper/XMLCreator.java
+++ b/preparehelper/src/main/java/com/donnnno/arcticons/helper/XMLCreator.java
@@ -108,15 +108,9 @@ public class XMLCreator {
         }
 
         // Copy files
-        copyFile(pathXml, assetPath);
-        copyFile(appFilterPath, assetPath);
-        copyFile(appFilterPath, xmlDir);
-
-        // Remove the new xml file
-        File newXmlFile = new File(pathNewXml);
-        if (newXmlFile.exists()) {
-            newXmlFile.delete();
-        }
+        copyFile(pathXml, assetPath+"/drawable.xml");
+        copyFile(appFilterPath, assetPath+"/appfilter.xml");
+        copyFile(appFilterPath, xmlDir+"/appfilter.xml");
     }
 
     private static void appendCategory(StringBuilder output, String title, List<String> entries) {

--- a/preparehelper/src/main/java/com/donnnno/arcticons/helper/XMLCreator.java
+++ b/preparehelper/src/main/java/com/donnnno/arcticons/helper/XMLCreator.java
@@ -1,0 +1,155 @@
+package com.donnnno.arcticons.helper;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class XMLCreator {
+    private static List<String> drawables = new ArrayList<>();
+    private static List<String> folder = new ArrayList<>();
+    private static List<String> calendar = new ArrayList<>();
+    private static List<String> google = new ArrayList<>();
+    private static List<String> microsoft = new ArrayList<>();
+    private static List<String> emoji = new ArrayList<>();
+    private static List<String> numbers = new ArrayList<>();
+    private static List<String> symbols = new ArrayList<>();
+    private static List<String> number = new ArrayList<>();
+
+    private static final Pattern drawablePattern = Pattern.compile("drawable=\"([\\w_]+)\"");
+
+    public static void mergeNewDrawables(String pathXml, String pathNewXml, String assetPath, String iconsDir,
+                                         String xmlDir, String appFilterPath) throws IOException {
+
+        List<String> newDrawables = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(pathNewXml))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                Matcher matcher = drawablePattern.matcher(line);
+                if (matcher.find()) {
+                    newDrawables.add(matcher.group(1));
+                }
+            }
+        }
+        Collections.sort(newDrawables);
+
+        // Collect existing drawables
+        File iconsDirectory = new File(iconsDir);
+        File[] files = iconsDirectory.listFiles();
+
+        if (files != null) {
+            for (File file : files) {
+                String fileName = file.getName();
+                String newDrawable = fileName.substring(0, fileName.lastIndexOf('.'));
+
+                if (!newDrawables.contains(newDrawable)) {
+                    classifyDrawable(newDrawable);
+                }
+            }
+        }
+
+        int newIcons = newDrawables.size();
+        System.out.println("There are " + newIcons + " new icons");
+
+        // Remove duplicates and sort
+        drawables = new ArrayList<>(new HashSet<>(drawables));
+        Collections.sort(drawables);
+        folder = new ArrayList<>(new HashSet<>(folder));
+        Collections.sort(folder);
+        calendar = new ArrayList<>(new HashSet<>(calendar));
+        Collections.sort(calendar);
+        google = new ArrayList<>(new HashSet<>(google));
+        Collections.sort(google);
+        microsoft = new ArrayList<>(new HashSet<>(microsoft));
+        Collections.sort(microsoft);
+        emoji = new ArrayList<>(new HashSet<>(emoji));
+        Collections.sort(emoji);
+
+
+        // Build output
+        StringBuilder output = new StringBuilder("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<resources>\n<version>1</version>\n\n\t<category title=\"New\" />\n\t");
+        for (String newDrawable : newDrawables) {
+            output.append("<item drawable=\"").append(newDrawable).append("\" />\n\t");
+        }
+
+        appendCategory(output, "Folders", folder);
+        appendCategory(output, "Calendar", calendar);
+        appendCategory(output, "Google", google);
+        appendCategory(output, "Microsoft", microsoft);
+        appendCategory(output, "Symbols", symbols);
+        appendCategory(output, "Numbers", numbers);
+        appendCategory(output, "0-9", number);
+
+        // Iterate alphabet
+        char letter = 'a';
+        for (String entry : drawables) {
+            if (!entry.startsWith(String.valueOf(letter))) {
+                letter++;
+                output.append("\n\t<category title=\"").append(Character.toUpperCase(letter)).append("\" />\n\t");
+            }
+            output.append("<item drawable=\"").append(entry).append("\" />\n\t");
+        }
+        output.append("\n</resources>");
+
+        // Write to new_'filename'.xml in working directory
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(pathXml))) {
+            writer.write(output.toString());
+        }
+
+        // Copy files
+        copyFile(pathXml, assetPath);
+        copyFile(appFilterPath, assetPath);
+        copyFile(appFilterPath, xmlDir);
+
+        // Remove the new xml file
+        File newXmlFile = new File(pathNewXml);
+        if (newXmlFile.exists()) {
+            newXmlFile.delete();
+        }
+    }
+
+    private static void appendCategory(StringBuilder output, String title, List<String> entries) {
+        output.append("\n\t<category title=\"").append(title).append("\" />\n\t");
+        for (String entry : entries) {
+            output.append("<item drawable=\"").append(entry).append("\" />\n\t");
+        }
+    }
+
+    private static void copyFile(String sourcePath, String destinationPath) throws IOException {
+        Path source = Path.of(sourcePath);
+        Path destination = Path.of(destinationPath);
+        Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private static void classifyDrawable(String newDrawable) {
+        if (newDrawable.startsWith("folder_")) {
+            folder.add(newDrawable);
+        } else if (newDrawable.startsWith("calendar_")) {
+            calendar.add(newDrawable);
+        } else if (newDrawable.startsWith("google_")) {
+            google.add(newDrawable);
+        } else if (newDrawable.startsWith("microsoft_") || newDrawable.startsWith("xbox")) {
+            microsoft.add(newDrawable);
+        } else if (newDrawable.startsWith("emoji_")) {
+            emoji.add(newDrawable);
+        } else if (newDrawable.startsWith("letter_") || newDrawable.startsWith("number_")
+                || newDrawable.startsWith("currency_") || newDrawable.startsWith("symbol_")) {
+            symbols.add(newDrawable);
+        } else if (newDrawable.startsWith("_")) {
+            number.add(newDrawable);
+        } else {
+            drawables.add(newDrawable);
+        }
+    }
+}

--- a/preparehelper/src/main/java/com/donnnno/arcticons/helper/XMLCreator.java
+++ b/preparehelper/src/main/java/com/donnnno/arcticons/helper/XMLCreator.java
@@ -16,6 +16,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class XMLCreator {
+    private static List<String> newDrawables = new ArrayList<>();
     private static List<String> drawables = new ArrayList<>();
     private static List<String> folder = new ArrayList<>();
     private static List<String> calendar = new ArrayList<>();
@@ -31,8 +32,6 @@ public class XMLCreator {
     public static void mergeNewDrawables(String pathXml, String pathNewXml, String assetPath, String iconsDir,
                                          String xmlDir, String appFilterPath) throws IOException {
 
-        List<String> newDrawables = new ArrayList<>();
-
         try (BufferedReader reader = new BufferedReader(new FileReader(pathNewXml))) {
             String line;
             while ((line = reader.readLine()) != null) {
@@ -42,7 +41,6 @@ public class XMLCreator {
                 }
             }
         }
-        Collections.sort(newDrawables);
 
         // Collect existing drawables
         File iconsDirectory = new File(iconsDir);
@@ -59,10 +57,9 @@ public class XMLCreator {
             }
         }
 
-        int newIcons = newDrawables.size();
-        System.out.println("There are " + newIcons + " new icons");
-
         // Remove duplicates and sort
+        newDrawables = new ArrayList<>(new HashSet<>(newDrawables));
+        Collections.sort(newDrawables);
         drawables = new ArrayList<>(new HashSet<>(drawables));
         Collections.sort(drawables);
         folder = new ArrayList<>(new HashSet<>(folder));
@@ -78,11 +75,9 @@ public class XMLCreator {
 
 
         // Build output
-        StringBuilder output = new StringBuilder("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<resources>\n<version>1</version>\n\n\t<category title=\"New\" />\n\t");
-        for (String newDrawable : newDrawables) {
-            output.append("<item drawable=\"").append(newDrawable).append("\" />\n\t");
-        }
+        StringBuilder output = new StringBuilder("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<resources>\n<version>1</version>\n");
 
+        appendCategory(output, "New", newDrawables);
         appendCategory(output, "Folders", folder);
         appendCategory(output, "Calendar", calendar);
         appendCategory(output, "Google", google);
@@ -90,19 +85,11 @@ public class XMLCreator {
         appendCategory(output, "Symbols", symbols);
         appendCategory(output, "Numbers", numbers);
         appendCategory(output, "0-9", number);
+        appendCategory(output, "A-Z", drawables);
 
-        // Iterate alphabet
-        char letter = 'a';
-        for (String entry : drawables) {
-            if (!entry.startsWith(String.valueOf(letter))) {
-                letter++;
-                output.append("\n\t<category title=\"").append(Character.toUpperCase(letter)).append("\" />\n\t");
-            }
-            output.append("<item drawable=\"").append(entry).append("\" />\n\t");
-        }
         output.append("\n</resources>");
-
-        // Write to new_'filename'.xml in working directory
+        
+        // Write to drawable.xml in res directory
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(pathXml))) {
             writer.write(output.toString());
         }

--- a/preparehelper/src/main/java/com/donnnno/arcticons/helper/XMLCreator.java
+++ b/preparehelper/src/main/java/com/donnnno/arcticons/helper/XMLCreator.java
@@ -2,6 +2,7 @@ package com.donnnno.arcticons.helper;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -40,7 +41,10 @@ public class XMLCreator {
                     newDrawables.add(matcher.group(1));
                 }
             }
+        }catch(FileNotFoundException e){
+            System.out.println("XML file: newdrawables.xml not found");
         }
+
 
         // Collect existing drawables
         File iconsDirectory = new File(iconsDir);
@@ -49,14 +53,13 @@ public class XMLCreator {
         if (files != null) {
             for (File file : files) {
                 String fileName = file.getName();
-                String newDrawable = fileName.substring(0, fileName.lastIndexOf('.'));
+                String IconDrawable = fileName.substring(0, fileName.lastIndexOf('.'));
 
-                if (!newDrawables.contains(newDrawable)) {
-                    classifyDrawable(newDrawable);
+                if (!newDrawables.contains(IconDrawable)) {
+                    classifyDrawable(IconDrawable);
                 }
             }
         }
-
         // Remove duplicates and sort
         newDrawables = new ArrayList<>(new HashSet<>(newDrawables));
         Collections.sort(newDrawables);


### PR DESCRIPTION
this moves the creation of the drawable.xml and the copy of the appfilter file to Android studio.
Also it adds an option to the preparerelease script to allow keeping the the current new drawables and add new icons to it.
This allows the script to be run in between releases without the need to revert these changes to have all new icons in new.
```
usage: preparerelease.py [-h] [--checkonly] [--new] ARCTICONS_DIR

positional arguments:
  ARCTICONS_DIR  Path to the Arcticons directory

options:
  -h, --help     show this help message and exit
  --checkonly    Run checks only
  --new          Run a new Release

```

Instead of of having a category for every letter i merged them to A-Z. To have an Specific Letter you will still be able to scroll to it with the scrollbar #1938