### PR TITLE
Fixes & Additions

### DIFF
--- a/other/abema_tv.svg
+++ b/other/abema_tv.svg
@@ -1,0 +1,17 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m38.88,32.54c1.58,0 2.85,1.27 2.85,2.85c0,1.58 -1.27,2.86 -2.85,2.86c-1.58,0 -2.86,-1.28 -2.86,-2.86c0,-1.58 1.28,-2.85 2.86,-2.85z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m22.23,20.64c0.78,0 1.42,0.64 1.42,1.43c0,0.79 -0.64,1.43 -1.42,1.43c-0.79,0 -1.43,-0.64 -1.43,-1.43c0,-0.79 0.64,-1.43 1.43,-1.43z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m14.14,32.54c1.57,0 2.85,1.27 2.85,2.85c0,1.58 -1.28,2.86 -2.85,2.86c-1.58,0 -2.86,-1.28 -2.86,-2.86c0,-1.58 1.28,-2.85 2.86,-2.85z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_3" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m9.43,32.72l6.59,-2.22l-1.38,-4.11l-6.59,2.21l1.38,4.12z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_4" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m33.88,22.78c0.79,0 1.43,0.64 1.43,1.43c0,0.79 -0.64,1.43 -1.43,1.43c-0.78,0 -1.42,-0.64 -1.42,-1.43c0,-0.79 0.64,-1.43 1.42,-1.43z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_5" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m27.22,26.19c1.63,0.24 2.84,1.15 2.7,2.03c-0.13,0.88 -1.55,1.39 -3.18,1.15c-1.62,-0.25 -2.83,-1.16 -2.7,-2.04c0.14,-0.88 1.56,-1.39 3.18,-1.14z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_6" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m19.37,27.78c-1.9,2.85 1.9,5.71 4.12,4.12c1.59,-1.27 3.69,-1.75 4.83,0.54c1.52,2.95 6.28,1.05 5.33,-2.76c-0.96,-5.71 -11.42,-6.66 -14.28,-1.9z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_7" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m16.52,37.29l20.12,0" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_8" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m38.4,32.54c1.91,-3.81 -1.9,-10.47 0,-15.23c1.91,-4.76 -0.95,-6.66 -4.75,-2.85c-2.86,2.85 -5.71,2.85 -7.62,-0.96c-2.85,-5.71 -6.66,-4.75 -6.66,1.91c0,5.71 -3.4,7.88 -3.44,9.66" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_9" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m11.88,23.65l-1.09,2.2l-2.2,-1.09" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_10" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m11.63,33.81l-1.64,0.55q-1.65,0.56 -2.2,-1.09l-1.39,-4.12q-0.55,-1.64 1.1,-2.19l6.58,-2.22q1.65,-0.55 2.2,1.1l1.38,4.11q0.56,1.65 -1.09,2.2l-1.64,0.55" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_11" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -1,5 +1,48 @@
 <resources>
 
+	<!-- Circa -->
+	<item component="ComponentInfo{com.gmg.icontheme.circa.iconpack/com.gmg.icontheme.circa.iconpack.activities.SplashActivity}" drawable="gmg_circa_icon"/>
+
+	<!-- Carrion -->
+	<item component="ComponentInfo{us.spotco.carrion/us.spotco.carrion.MainActivity}" drawable="spotco_carrion"/>
+
+	<!-- 카카오웹툰 -->
+	<item component="ComponentInfo{net.daum.android.webtoon/net.daum.android.WebtoonActivity}" drawable="kakao_webtoon"/>
+
+	<!-- 코미코 -->
+	<item component="ComponentInfo{com.wisdomhouse.justoon/io.comico.ui.activity.SplashActivity}" drawable="comico_justoon"/>
+
+	<!-- Squircle Dark -->
+	<item component="ComponentInfo{com.square.dark.iconpack/com.square.dark.iconpack.activities.SplashActivity}" drawable="squircle_dark_icon"/>
+	<item component="ComponentInfo{com.panotogomo.squircledark/com.panotogomo.squircledark.activities.SplashActivity}" drawable="squircle_dark_icon"/>
+
+	<!-- Numbers -->
+	<item component="ComponentInfo{es.aroundpixels.hsknumberslite/com.aroundpixels.baselibrary.mvp.view.splashscreen.SplashScreenView}" drawable="numbers_es_ap"/>
+
+	<!-- Abema -->
+	<item component="ComponentInfo{tv.abema/tv.abema.components.activity.LauncherActivity}" drawable="abema_tv"/>
+
+	<!-- Test DPC -->
+	<item component="ComponentInfo{com.afwsamples.testdpc/com.afwsamples.testdpc.SetupManagementLaunchActivity}" drawable="test_dpc"/>
+	<item component="ComponentInfo{com.afwsamples.testdpc/com.afwsamples.testdpc.PolicyManagementActivity}" drawable="test_dpc"/>
+
+	<!-- Folder Widget -->
+	<item component="ComponentInfo{pub.hanks.appfolderwidget/com.android.app.ap.h.MainActivity}" drawable="folder_widget"/>
+
+	<!-- Octadark -->
+	<item component="ComponentInfo{com.panotogomo.octadark/com.panotogomo.octadark.activities.SplashActivity}" drawable="octa_dark_icon"/>
+	<item component="ComponentInfo{com.spaceman.octane/com.spaceman.octane.MainActivity}" drawable="octa_dark_icon"/>
+
+	<!-- Aplin -->
+	<item component="ComponentInfo{com.nagopy.android.aplin/com.nagopy.android.aplin.ui.main.MainActivity}" drawable="nagopy_aplin"/>
+
+	<!-- Whale -->
+	<item component="ComponentInfo{com.naver.whale/com.google.android.apps.chrome.Main}" drawable="naver_whale"/>
+
+	<!-- Easy Coder -->
+	<item component="ComponentInfo{com.amensah.easycoder/com.amensah.easycoder.SplashActivity}" drawable="easy_coder"/>
+	<item component="ComponentInfo{com.amensah.easycoder.python/com.amensah.easycoder.SplashActivity}" drawable="easy_coder"/>
+	
 	<!-- #DRIVE -->
 	<item component="ComponentInfo{com.pixelperfectdude.htdrive/com.unity3d.player.UnityPlayerActivity}" drawable="drive"/>
 
@@ -29442,7 +29485,6 @@
 	<!-- Webtoon -->
 	<item component="ComponentInfo{com.naver.linewebtoon/com.naver.linewebtoon.splash.SplashActivity}" drawable="webtoon"/>
 	<item component="ComponentInfo{com.nhn.android.webtoon/com.naver.webtoon.splash.SplashActivity}" drawable="webtoon"/>
-	<item component="ComponentInfo{net.daum.android.webtoon/net.daum.android.WebtoonActivity}" drawable="webtoon"/>
 
 	<!-- WebTube -->
 	<item component="ComponentInfo{cz.martykan.webtube/cz.martykan.webtube.MainActivity}" drawable="youtube"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -24246,7 +24246,6 @@
 	<item component="ComponentInfo{com.simplemobiletools.applauncher.pro/com.simplemobiletools.applauncher.pro.activities.SplashActivity.Blue_grey}" drawable="simpleapplauncher"/>
 	<item component="ComponentInfo{com.simplemobiletools.applauncher.pro/com.simplemobiletools.applauncher.pro.activities.SplashActivity.Grey_black}" drawable="simpleapplauncher"/>
 	<item component="ComponentInfo{com.simplemobiletools.applauncher.pro/com.simplemobiletools.applauncher.pro.activities.SplashActivity.Red}" drawable="simpleapplauncher"/>
-	<item component="ComponentInfo{de.mlex.same/de.mlex.same.MainActivity}" drawable="simpleapplauncher"/>
 
 	<!-- Simple Music Player -->
 	<item component="ComponentInfo{com.simplemobiletools.musicplayer/com.simplemobiletools.musicplayer.activities.SplashActivity.Pink}" drawable="simplemusicplayer"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -5648,6 +5648,7 @@
 	<item component="ComponentInfo{com.philliphsu.clock2/com.philliphsu.clock2.MainActivity}" drawable="clock"/>
 	<item component="ComponentInfo{net.xisberto.timerpx/net.xisberto.timerpx.MainActivity}" drawable="clock"/>
 	<item component="ComponentInfo{com.hihonor.deskclock/com.android.deskclock.AlarmsMainActivity}" drawable="clock"/>
+	<item component="ComponentInfo{de.dieterthiess.tactictime/de.dieterthiess.tactictime.activity.TacticTimeActivity}" drawable="clock"/>
 
 	<!-- Clockify -->
 	<item component="ComponentInfo{me.clockify.android/me.clockify.android.presenter.SplashActivity}" drawable="clockify"/>
@@ -8632,7 +8633,10 @@
 
 	<!-- EweSticker -->
 	<item component="ComponentInfo{com.fredhappyface.ewesticker/com.fredhappyface.ewesticker.MainActivity}" drawable="ewesticker"/>
-
+	
+	<!-- EX Kernel Manager -->
+	<item component="ComponentInfo{flar2.exkernelmanager/a.b}" drawable="ex_kernel_manager"/>
+	
 	<!-- Exact SRXP -->
 	<item component="ComponentInfo{com.secureceipt/crc6472824d8024db8668.SplashScreen}" drawable="srxp"/>
 
@@ -15890,6 +15894,7 @@
 
 	<!-- MetaGer Search -->
 	<item component="ComponentInfo{de.metager.metagerapp.fdroid/de.metager.metagerapp.MainActivity}" drawable="metager"/>
+	<item component="ComponentInfo{de.metager.metagerapp.manual/de.metager.metagerapp.MainActivity}" drawable="metager"/>
 
 	<!-- MetaMask -->
 	<item component="ComponentInfo{io.metamask/io.metamask.MainActivity}" drawable="metamask"/>
@@ -24197,6 +24202,7 @@
 	<item component="ComponentInfo{com.simplemobiletools.applauncher.pro/com.simplemobiletools.applauncher.pro.activities.SplashActivity.Blue_grey}" drawable="simpleapplauncher"/>
 	<item component="ComponentInfo{com.simplemobiletools.applauncher.pro/com.simplemobiletools.applauncher.pro.activities.SplashActivity.Grey_black}" drawable="simpleapplauncher"/>
 	<item component="ComponentInfo{com.simplemobiletools.applauncher.pro/com.simplemobiletools.applauncher.pro.activities.SplashActivity.Red}" drawable="simpleapplauncher"/>
+	<item component="ComponentInfo{de.mlex.same/de.mlex.same.MainActivity}" drawable="simpleapplauncher"/>
 
 	<!-- Simple Music Player -->
 	<item component="ComponentInfo{com.simplemobiletools.musicplayer/com.simplemobiletools.musicplayer.activities.SplashActivity.Pink}" drawable="simplemusicplayer"/>
@@ -26572,6 +26578,7 @@
 
 	<!-- Tempo -->
 	<item component="ComponentInfo{com.cappielloantonio.tempo/com.cappielloantonio.tempo.ui.activity.MainActivity}" drawable="tempo"/>
+	<item component="ComponentInfo{com.cappielloantonio.notquitemy.tempo/com.cappielloantonio.tempo.ui.activity.MainActivity}" drawable="tempo"/>
 
 	<!-- Tempus Romanum -->
 	<item component="ComponentInfo{com.dev.xavier.tempusromanum/com.dev.xavier.tempusromanum.MainActivity}" drawable="tempusromanum"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -18247,6 +18247,7 @@
 	<!-- NFC Reader -->
 	<item component="ComponentInfo{com.github.muellerma.nfcreader/com.github.muellerma.nfcreader.MainActivity}" drawable="nfc_reader"/>
 	<item component="ComponentInfo{se.anyro.nfc_reader/se.anyro.nfc_reader.TagViewer}" drawable="nfcreader"/>
+	<item component="ComponentInfo{de.dieterthiess.inkkey/de.dieterthiess.waveshare.activity.MainActivity}" drawable="nfc_reader"/>
 
 	<!-- Nfc Tasks -->
 	<item component="ComponentInfo{com.wakdev.nfctasks/com.wakdev.nfctasks.MainActivity}" drawable="nfc_tasks"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -29674,6 +29674,7 @@
 	<!-- Wi-Fi Info -->
 	<item component="ComponentInfo{com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.SplashActivity}" drawable="wifi_info"/>
 	<item component="ComponentInfo{com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.MainActivity}" drawable="wifi_info"/>
+	<item component="ComponentInfo{com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.ui.MainActivity}" drawable="wifi_info"/>
 
 	<!-- Wi-Fi Privacy Police -->
 	<item component="ComponentInfo{be.uhasselt.privacypolice/be.uhasselt.privacypolice.PreferencesActivity}" drawable="wifiprivacy"/>

--- a/other/comico_justoon.svg
+++ b/other/comico_justoon.svg
@@ -1,0 +1,8 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m38.34,12.87q-1.1,-4.43 -5.53,-4.43l-19.93,-1.11q-3.32,0 -3.32,3.32l-1.84,23.25q-0.37,6.64 6.27,4.43l7.75,-2.22q1.84,-0.73 3.32,0l8.86,4.43c1.1,0.56 2.21,-0.83 1.38,-2.21l-2.27,-4.21c-0.44,-0.88 -0.22,-1.55 1.25,-2.06l2.96,-0.74q3.32,-0.74 3.04,-2.95l-1.94,-15.5z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m27.79,24.2c1.14,-1.37 3.64,0.57 2.84,2.12a8.12,8 15.99 1 1 -0.04,-9.15c0.84,1.51 -1.66,3.17 -2.8,2.08a4.56,4.56 296.59 1 0 0,4.95z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/easy_coder.svg
+++ b/other/easy_coder.svg
@@ -1,0 +1,12 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m23.12,31.13l3.2,-8.55" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m29.28,33.7q0,1.14 -1.14,1.14l-1.71,0q-1.33,0 -1.71,1.15q-0.38,-1.15 -1.71,-1.15l-1.72,0q-1.14,0 -1.14,-1.14" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m21.29,24.57l-4.56,1.71l4.51,1.72" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_3" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m28.14,24.57l4.57,1.71l-4.57,1.72" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_4" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m13.3,20c5.71,2.29 10.28,1.15 14.84,-2.28q0,2.28 -1.14,3.43c3.43,1.14 5.71,-2.29 8.56,-2.29q1.14,0 2.86,1.14q0.57,-2.28 -1.15,-3.42q0,-2.28 2.29,-3.42q-2.29,-1.15 -4.57,1.14c0,-2.29 -2.28,-4.57 -4.56,-5.71q1.14,1.14 1.14,3.42c-4.57,-4.56 -7.99,-4.56 -12.56,-4.56q1.71,1.14 2.28,2.28c-4.56,0 -7.99,2.28 -12.55,-2.28c-1.14,6.85 1.14,10.27 4.56,12.55l0,5.71q0,2.29 -2.28,2.29q2.28,0 2.28,2.28l0,7.99q0,2.28 3.43,2.28" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_5" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m32.71,40.55q2.28,0 2.28,-2.28l0,-7.99q0,-2.28 2.28,-2.28q-2.28,0 -2.28,-2.29l0,-6.62" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_6" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/folder_widget.svg
+++ b/other/folder_widget.svg
@@ -1,0 +1,21 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m11.49,6.94c2.51,0 4.55,2.04 4.55,4.55c0,2.52 -2.04,4.55 -4.55,4.55c-2.52,0 -4.56,-2.03 -4.56,-4.55c0,-2.51 2.04,-4.55 4.56,-4.55z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m11.49,19.46c2.51,0 4.55,2.03 4.55,4.55c0,2.51 -2.04,4.55 -4.55,4.55c-2.52,0 -4.56,-2.04 -4.56,-4.55c0,-2.52 2.04,-4.55 4.56,-4.55z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m11.49,32c2.49,0 4.52,2.03 4.52,4.52c0,2.5 -2.03,4.52 -4.52,4.52c-2.5,0 -4.53,-2.02 -4.53,-4.52c0,-2.49 2.03,-4.52 4.53,-4.52z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_3" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m24,6.94c2.51,0 4.55,2.04 4.55,4.55c0,2.52 -2.04,4.55 -4.55,4.55c-2.51,0 -4.55,-2.03 -4.55,-4.55c0,-2.51 2.04,-4.55 4.55,-4.55z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_4" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m24,19.46c2.51,0 4.55,2.03 4.55,4.55c0,2.51 -2.04,4.55 -4.55,4.55c-2.51,0 -4.55,-2.04 -4.55,-4.55c0,-2.52 2.04,-4.55 4.55,-4.55z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_5" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m24,32.02c2.5,0 4.52,2.02 4.52,4.52c0,2.49 -2.02,4.52 -4.52,4.52c-2.5,0 -4.52,-2.03 -4.52,-4.52c0,-2.5 2.02,-4.52 4.52,-4.52z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_6" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m36.51,6.94c2.52,0 4.56,2.04 4.56,4.55c0,2.52 -2.04,4.55 -4.56,4.55c-2.51,0 -4.55,-2.03 -4.55,-4.55c0,-2.51 2.04,-4.55 4.55,-4.55z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_7" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m36.51,19.46c2.52,0 4.56,2.03 4.56,4.55c0,2.51 -2.04,4.55 -4.56,4.55c-2.51,0 -4.55,-2.04 -4.55,-4.55c0,-2.52 2.04,-4.55 4.55,-4.55z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_8" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m36.51,32c2.5,0 4.53,2.03 4.53,4.52c0,2.5 -2.03,4.52 -4.53,4.52c-2.49,0 -4.52,-2.02 -4.52,-4.52c0,-2.49 2.03,-4.52 4.52,-4.52z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_9" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m6.93,11.49l0,25.03" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_10" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m16.04,36.52l0,-25.03" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_11" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m11.49,6.94l25.02,0" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_12" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m11.49,16.04l25.02,0" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_13" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m11.49,19.46l12.51,0" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_14" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m11.49,28.56l12.51,0" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_15" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/gmg_circa_icon.svg
+++ b/other/gmg_circa_icon.svg
@@ -1,0 +1,10 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m24,2.77c11.73,0 21.23,9.5 21.23,21.23c0,11.73 -9.5,21.23 -21.23,21.23c-11.73,0 -21.23,-9.5 -21.23,-21.23c0,-11.73 9.5,-21.23 21.23,-21.23z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m24,18.58c3,0 5.42,2.42 5.42,5.42c0,3 -2.42,5.42 -5.42,5.42c-3,0 -5.42,-2.42 -5.42,-5.42c0,-3 2.42,-5.42 5.42,-5.42z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m24,13.38c5.86,0 10.62,4.76 10.62,10.62c0,5.86 -4.76,10.62 -10.62,10.62c-5.86,0 -10.62,-4.76 -10.62,-10.62c0,-5.86 4.76,-10.62 10.62,-10.62z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_3" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m29.67,33l6.81,0a15.37,15.44 267.89 1 1 0,-18l-6.81,0" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_4" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/kakao_webtoon.svg
+++ b/other/kakao_webtoon.svg
@@ -1,0 +1,7 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m41,17.5l0,13l-12,0l-5,-11l-5,11l-12,0l0,-13l6,0l0,11l5,-11l12,0l5,11l0,-11l6,0z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/nagopy_aplin.svg
+++ b/other/nagopy_aplin.svg
@@ -1,0 +1,13 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m35.5,18.79l-1.58,3.24" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m41.55,29.16l-3.6,-0.22" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m31.43,23.49c0.31,0.54 0.12,1.22 -0.41,1.53c-0.53,0.3 -1.22,0.12 -1.52,-0.41c-0.31,-0.54 -0.13,-1.22 0.4,-1.53c0.54,-0.3 1.22,-0.12 1.53,0.41z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_3" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m24.22,35l-8,0l3,-6l5,0c3,1 3,5 0,6z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_4" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m35.46,30.4c0.31,0.54 0.12,1.22 -0.41,1.53c-0.53,0.3 -1.21,0.12 -1.52,-0.41c-0.31,-0.54 -0.13,-1.22 0.41,-1.53c0.53,-0.31 1.21,-0.12 1.52,0.41z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_5" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m23.12,21.39c11.73,-5.69 20.8,9.85 10.08,17.27l-10.08,-17.27z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_6" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m6.96,33.47l11.56,-22.17c2.31,-4.44 8.52,-1.2 6.2,3.23l-11.55,22.17c-2.31,4.44 -8.52,1.2 -6.21,-3.23z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_7" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/naver_whale.svg
+++ b/other/naver_whale.svg
@@ -1,0 +1,10 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m24.07,19.17c0.7,0 1.27,0.61 1.27,1.36c0,0.74 -0.57,1.35 -1.27,1.35c-0.7,0 -1.27,-0.61 -1.27,-1.35c0,-0.75 0.57,-1.36 1.27,-1.36z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m17.32,37.03c11,-3 8,-23 21,-27c8,10 2,32 -21,27z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m12.32,33.03c-5,-5 -8,-12 -3,-22c-1,6 3,9 7,9.33c6,0.17 7,-10.33 22,-10.33" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_3" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m18.32,27.03c-3,5 -7,8 -12,10c3,1 7,1.5 11,0" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_4" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/numbers_es_ap.svg
+++ b/other/numbers_es_ap.svg
@@ -1,0 +1,11 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m32.44,15.04l-16.88,0l0,-4.22l16.88,0l0,4.22z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m7.13,20.31q16.87,0.53 33.74,0l0.01,3.16q-16.88,-0.52 -33.75,0l0,-3.16z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m12.4,7.65q11.6,0.53 23.2,0q-1.05,5.28 0,10.55q-11.6,-0.53 -23.2,0q1.05,-5.27 0,-10.55z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_3" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m16.09,23.47l-1.85,7.39" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_4" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m14.24,30.86q9.76,-0.53 17.49,-0.36c0.18,5.63 -1.4,5.63 -8.78,5.63q2.1,2.11 2.1,4.22c9.5,-1.06 10.55,-3.17 10.55,-12.66l-16.87,0l1.05,-4.22" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_5" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/octa_dark_icon.svg
+++ b/other/octa_dark_icon.svg
@@ -1,0 +1,11 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m31.23,41.5l10.13,-10.21l0,-14.58l-10.13,-10.21l-14.46,0l-10.13,10.21l0,14.58l10.13,10.21l14.46,0z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m38.83,17.8l0,12.4l-8.68,8.75l-12.3,0l-8.68,-8.75l0,-12.4l8.68,-8.75l12.3,0l8.68,8.75z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m27.47,23.86c5.21,-1.74 5.21,-11.29 -3.47,-11.29c-8.68,0 -8.68,9.55 -3.47,11.29c-5.21,1.74 -5.21,11.29 3.47,11.29c8.68,0 8.68,-9.55 3.47,-11.29z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_3" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m24,26.25c1.92,0 3.47,1.26 3.47,2.82c0,1.56 -1.55,2.82 -3.47,2.82c-1.92,0 -3.47,-1.26 -3.47,-2.82c0,-1.56 1.55,-2.82 3.47,-2.82z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_4" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m24,15.83c1.92,0 3.47,1.26 3.47,2.82c0,1.56 -1.55,2.82 -3.47,2.82c-1.92,0 -3.47,-1.26 -3.47,-2.82c0,-1.56 1.55,-2.82 3.47,-2.82z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_5" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/spotco_carrion.svg
+++ b/other/spotco_carrion.svg
@@ -1,0 +1,9 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m30.73,24.65c4.79,0 8.68,3.89 8.68,8.68c0,4.79 -3.89,8.68 -8.68,8.68c-4.8,0 -8.68,-3.89 -8.68,-8.68c0,-4.79 3.88,-8.68 8.68,-8.68z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m32.46,35.07l0,4.34l-3.47,0l0,-4.34l-4.34,0l0,-3.48l4.34,0l0,-4.34l3.47,0l0,4.34l4.34,0l0,3.48l-4.34,0z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m23.49,38.2q-0.86,0.34 -1.88,0.77c-8.24,-3.47 -13.02,-6.07 -13.02,-17.36l0,-9.54l13.02,-6.08l13.02,6.08l0,9.54q0,2.32 -0.23,3.82" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_3" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/squircle_dark_icon.svg
+++ b/other/squircle_dark_icon.svg
@@ -1,0 +1,8 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m31.81,30.69l0,-2.23q0,-1.11 -1.12,-1.11l-17.84,0q-3.35,0 -3.35,-3.35l0,-11.15q0,-3.35 3.35,-3.35l22.3,0c4.47,0 4.47,6.69 0,6.69l-17.84,0q-1.12,0 -1.12,1.12l0,2.23q0,1.11 1.12,1.11l17.84,0q3.35,0 3.35,3.35l0,11.15q0,3.35 -3.35,3.35l-22.3,0c-4.47,0 -4.47,-6.69 0,-6.69l17.84,0q1.12,0 1.12,-1.12z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m44,40l0,-32q0,-4 -4,-4l-32,0q-4,0 -4,4l0,32q0,4 4,4l32,0q4,0 4,-4z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>

--- a/other/test_dpc.svg
+++ b/other/test_dpc.svg
@@ -1,0 +1,14 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" enable-background="new 0 0 48.0 48.0" version="1.1" xml:space="preserve">
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m39.75,15.34l0,17.32l-15.75,9.45l-15.75,-9.45l0,-17.32l15.75,-9.45l15.75,9.45z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_1" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m24,32.89l7.83,-4.66l0,-8.46l-7.83,-4.66l-7.83,4.66l0,8.46l7.83,4.66z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_2" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m31.87,19.8l7.88,4.72" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_3" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m16.4,37.48l7.6,-4.59" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_4" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m16.17,19.74l0,-9.13" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_5" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m20.85,27.15l0,-3.94q0,-0.78 0.79,-0.78l4.66,0q0.85,0 0.85,0.78l0,3.94q0,0.79 -0.79,0.79l-4.72,0q-0.79,0 -0.79,-0.79z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_6" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m22.43,22.43c-0.4,-3.15 3.54,-3.15 3.14,0" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_7" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+  <path d="m24,24c0.65,0 1.18,0.53 1.18,1.18c0,0.65 -0.53,1.18 -1.18,1.18c-0.65,0 -1.18,-0.53 -1.18,-1.18c0,-0.65 0.53,-1.18 1.18,-1.18z" fill="#000000" fill-opacity="0" fill-rule="nonzero" id="svg_8" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="1"/>
+ </g>
+</svg>


### PR DESCRIPTION
# Fixed/Added
- Metager (non F-Droid)
- Tempo (F-Droid)
- EX Kernel Manager (existing Icon)
- WiFi Info
# Reuse existing
- eInk-QR
- ~Same~ -> #1980 
- Tactic Time
# New
- Aplin
- Octadark/Octane Icon Pack
- Easy Coder
- Whale (Browser)
- Folder Widget
- Abema
- Numbers (follow-up on recent 'yct')
- Carrion
- Squircle/Square Dark Icon Pack
- 코미코
- 카카오웹툰 (reuse -> new)
- Circa Icon Pack
- Test DPC
# 
- Thinking about giving the 'Kustom' app family their own icons. Reuse was probably fine but with currently 5 Apps and 3 Pro Keys and likely more than 1 installed at a time that might be something worth considering.

- Maybe a different/new Icon for 'com.sadellie.unitto' allowing for easier identification.
(Given that the display name is actually just "Calculator")

- Going to clearly label/include the "Icon Pack" in the Appname from now on as well. Most of them (plenty more on the way) won't see much use but that's fine.

- Another guaranteed ~700 Icons from my to-do list within the near future hopefully.