### PR TITLE
Remove freedesktop-theme submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "freedesktop-theme"]
-	path = freedesktop-theme
-	url = git@github.com:Donnnno/Arcticons-Linux.git
-	branch = main


### PR DESCRIPTION
Removes the Arcticons-Linux submodule, as I added the Arcticons repo as a submodule in Arcticons-Linux, this makes it easier to fetch the icons.