### PR TITLE
recycling Pixel Tipps for Assus TipListActivity (same icon)

### DIFF
--- a/newicons/appfilter.xml
+++ b/newicons/appfilter.xml
@@ -27832,6 +27832,7 @@
 
 	<!-- Pixel Tips -->
 	<item component="ComponentInfo{com.google.android.apps.tips/com.google.android.apps.tips.TipsMain}" drawable="pixel_tips"/>
+	<item component="ComponentInfo{com.asus.tips/com.asus.tips.TipListActivity}" drawable="pixel_tips"/>
 
 	<!-- Pixel Wheels -->
 	<item component="ComponentInfo{com.agateau.tinywheels.android/com.agateau.pixelwheels.android.AndroidLauncher}" drawable="pixelwheels"/>


### PR DESCRIPTION
Hi there, 

just recycling one icon for Zenfones (10).
(hopefully my line end is correct this time)