### PR TITLE
Re-add mappings for Fossify Paint

### DIFF
--- a/newicons/appfilter.xml
+++ b/newicons/appfilter.xml
@@ -15480,6 +15480,24 @@
 	<item component="ComponentInfo{org.fossify.draw/org.fossify.draw.activities.SplashActivity.Grey_black}" drawable="fossify_draw"/>
 	<item component="ComponentInfo{org.fossify.draw/org.fossify.draw.activities.SplashActivity.Red}" drawable="fossify_draw"/>
 	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Pink}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Purple}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Deep_purple}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Indigo}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Blue}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Light_blue}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Cyan}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Teal}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Green}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Light_green}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Lime}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Yellow}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Amber}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Orange}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Deep_orange}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Brown}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Blue_grey}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Grey_black}" drawable="fossify_draw"/>
+	<item component="ComponentInfo{org.fossify.paint/org.fossify.paint.activities.SplashActivity.Red}" drawable="fossify_draw"/>
 
 	<!-- Fossify File Manager -->
 	<item component="ComponentInfo{org.fossify.filemanager/org.fossify.filemanager.activities.SplashActivity.Pink}" drawable="fossify_filemanager"/>


### PR DESCRIPTION
The previously submitted mappings for Fossify Paint in #2487 were incorrect (and was probably rejected by the build process since I don't see them in the current appfilter.xml file). This re-add them with the correct values.