### PR TITLE
New email address 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-arcticons@onnno.nl.
+hello@arcticons.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/Privacy_Policy.md
+++ b/Privacy_Policy.md
@@ -14,9 +14,9 @@ You can modify what you send in the email:
 
 This information is solely used for the icon request and remains private. **You're also fully controlling what data you send to us via email.**
 
-All mails are securely stored on [Disroot's servers](https://disroot.org/en/privacy_policy), and are regularly deleted (usually within three months).
+All mails are securely stored with [zero-access encryption](https://proton.me/security/zero-access-encryption) via Proton Mail's servers, and are regularly deleted (usually within three months).
 
 The requested icons will be gathered and into our database. All identifiable information is stripped in the process, only the apps, icons, date of request will be visible in our publicly visible [Requests Dashboard](https://arcticons-team.github.io/Arcticons/requests.html).
 
 Last modified:
-**19 January 2025**
+**11 Juni 2024**

--- a/Privacy_Policy.md
+++ b/Privacy_Policy.md
@@ -14,9 +14,9 @@ You can modify what you send in the email:
 
 This information is solely used for the icon request and remains private. **You're also fully controlling what data you send to us via email.**
 
-All mails are securely stored with [zero-access encryption](https://proton.me/security/zero-access-encryption) via Proton Mail's servers, and are regularly deleted (usually within three months).
+All mails are securely stored on [Disroot's servers](https://disroot.org/en/privacy_policy), and are regularly deleted (usually within three months).
 
 The requested icons will be gathered and into our database. All identifiable information is stripped in the process, only the apps, icons, date of request will be visible in our publicly visible [Requests Dashboard](https://arcticons-team.github.io/Arcticons/requests.html).
 
 Last modified:
-**11 Juni 2024**
+**19 January 2025**

--- a/app/src/black/play/contact-email.txt
+++ b/app/src/black/play/contact-email.txt
@@ -1,1 +1,1 @@
-arcticons-support@onnno.nl
+hello@arcticons.com

--- a/app/src/black/play/listings/en-US/full-description.txt
+++ b/app/src/black/play/listings/en-US/full-description.txt
@@ -14,6 +14,6 @@ You'll need to apply the icon pack with Theme Park to use it.
 
 <b>SUPPORT</b>
 If you need help, have questions or some feedback? You are welcome to reach out to me at these places:
-• 📧 arcticons-support@onnno.nl
+• 📧 hello@arcticons.com
 • 💻 https://fosstodon.org/@donno
 • 🌐 https://github.com/Arcticons-Team/Arcticons

--- a/app/src/black/res/values/dashboard_configurations.xml
+++ b/app/src/black/res/values/dashboard_configurations.xml
@@ -13,9 +13,9 @@
 
     <string name="home_description">
         <![CDATA[
-            <p>❄️ Arcticons is a line based <a href="https://github.com/Donnnno/Arcticons/">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
+            <p>❄️ Arcticons is a line based <a href="https://github.com/Arcticons-Team/Arcticons">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
             <br>
-            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:arcticons-support@onnno.nl">email</a> me if you have questions :)</p>
+            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
             <br>
             <p>🎨 You can get priority icon requests <a href="https://ko-fi.com/donno_">on Ko-fi</a>, if you want your icons made within the next update.</p>
             <br>

--- a/app/src/dayNight/play/contact-email.txt
+++ b/app/src/dayNight/play/contact-email.txt
@@ -1,1 +1,1 @@
-arcticons-support@onnno.nl
+hello@arcticons.com

--- a/app/src/dayNight/play/listings/en-US/full-description.txt
+++ b/app/src/dayNight/play/listings/en-US/full-description.txt
@@ -14,6 +14,6 @@ You'll need to apply the icon pack with Theme Park to use it.
 
 <b>SUPPORT</b>
 If you need help, have questions or some feedback? You are welcome to reach out to me at these places:
-• 📧 arcticons-support@onnno.nl
+• 📧 hello@arcticons.com
 • 💻 https://fosstodon.org/@donno
 • 🌐 https://github.com/Arcticons-Team/Arcticons

--- a/app/src/dayNight/res/values/dashboard_configurations.xml
+++ b/app/src/dayNight/res/values/dashboard_configurations.xml
@@ -13,9 +13,9 @@
 
     <string name="home_description">
         <![CDATA[
-            <p>❄️ Arcticons is a line based <a href="https://github.com/Donnnno/Arcticons/">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
+            <p>❄️ Arcticons is a line based <a href="https://github.com/Arcticons-Team/Arcticons">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
             <br>
-            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:arcticons-support@onnno.nl">email</a> me if you have questions :)</p>
+            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
             <br>
             <p>🎨 You can get priority icon requests <a href="https://ko-fi.com/donno_">on Ko-fi</a>, if you want your icons made within the next update.</p>
             <br>

--- a/app/src/main/res/values/dashboard_configurations.xml
+++ b/app/src/main/res/values/dashboard_configurations.xml
@@ -149,8 +149,8 @@
     <!-- Email to use when sending icon requests.
         Regular request email address will be used to send bug reports.
         You can leave "premium_request_email" empty to use the regular request's email to send premium icon requests. -->
-    <string name="regular_request_email">arcticons@onnno.nl</string>
-    <string name="premium_request_email">arcticons@onnno.nl</string>
+    <string name="regular_request_email">requests@arcticons.com</string>
+    <string name="premium_request_email">requests@arcticons.com</string>
 
     <!-- Icon request email subjects. Leave empty to use default Subject. -->
     <string name="regular_request_email_subject"></string>
@@ -232,7 +232,7 @@
         ex: <string-array name="about_social_links"></string-array>
         -->
     <string-array name="about_social_links">
-        <item>arcticons-support@onnno.nl</item>
+        <item>hello@arcticons.com</item>
         <item>https://matrix.to/#/#arcticons-central:matrix.org</item>
         <item>https://github.com/Arcticons-Team</item>
         <item>https://instagram.com/onno_onno_onno</item>

--- a/app/src/normal/play/contact-email.txt
+++ b/app/src/normal/play/contact-email.txt
@@ -1,1 +1,1 @@
-arcticons-support@onnno.nl
+hello@arcticons.com

--- a/app/src/normal/play/listings/en-US/full-description.txt
+++ b/app/src/normal/play/listings/en-US/full-description.txt
@@ -14,6 +14,6 @@ You'll need to apply the icon pack with Theme Park to use it.
 
 <b>SUPPORT</b>
 If you need help, have questions or some feedback? You are welcome to reach out to me at these places:
-• 📧 arcticons-support@onnno.nl
+• 📧 hello@arcticons.com
 • 💻 https://fosstodon.org/@donno
 • 🌐 https://github.com/Arcticons-Team/Arcticons

--- a/app/src/normal/res/values/dashboard_configurations.xml
+++ b/app/src/normal/res/values/dashboard_configurations.xml
@@ -15,9 +15,9 @@
 
     <string name="home_description">
         <![CDATA[
-            <p>❄️ Arcticons is a line based <a href="https://github.com/Donnnno/Arcticons/">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
+            <p>❄️ Arcticons is a line based <a href="https://github.com/Arcticons-Team/Arcticons">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
             <br>
-            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:arcticons-support@onnno.nl">email</a> me if you have questions :)</p>
+            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
             <br>
             <p>🎨 You can get priority icon requests <a href="https://ko-fi.com/donno_">on Ko-fi</a>, if you want your icons made within the next update.</p>
             <br>

--- a/app/src/you/play/contact-email.txt
+++ b/app/src/you/play/contact-email.txt
@@ -1,1 +1,1 @@
-arcticons-support@onnno.nl
+hello@arcticons.com

--- a/app/src/you/play/listings/en-US/full-description.txt
+++ b/app/src/you/play/listings/en-US/full-description.txt
@@ -9,10 +9,10 @@ If you're missing icons, you can submit an icon request or create them yourself!
 You must have a device that runs on *Android 12 or above* to use the dynamic colors.
 
 *Use one of these launchers to apply the dynamic color scheme:*
-Smart • Nova  •  Niagara • Hyperion  • Lawnchair  • Kvaesisto
+Smart • Nova • Niagara • Hyperion • Lawnchair • Kvaesisto
 
 <b>SUPPORT</b>
 If you need help, have questions or some feedback? You are welcome to reach out to me at these places:
-• 📧 arcticons-support@onnno.nl
+• 📧 hello@arcticons.com
 • 💻 https://fosstodon.org/@donno
-• 🌐 https://github.com/Arcticons-Team/Arcticons
+• 🌐 https://github.com/Arcticons-Team/Arcticons

--- a/app/src/you/res/values/dashboard_configurations.xml
+++ b/app/src/you/res/values/dashboard_configurations.xml
@@ -13,9 +13,9 @@
 
     <string name="home_description">
         <![CDATA[
-            <p>❄️ Arcticons is a line based <a href="https://github.com/Donnnno/Arcticons/">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
+            <p>❄️ Arcticons is a line based <a href="https://github.com/Arcticons-Team/Arcticons">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
             <br>
-            <p>⚠️ Need help changing the color of your icons? Check out <a href="https://docs.arcticons.com/faq#how-do-i-change-my-material-you-color-palette">our knowledge base</a>. Or you can also <a href="mailto:arcticons-support@onnno.nl">email</a> me if you have questions :)</p>
+            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
             <br>
             <p>🎨 You can get priority icon requests <a href="https://ko-fi.com/donno_">on Ko-fi</a>, if you want your icons made within the next update.</p>
             <br>


### PR DESCRIPTION
Linked to #2450 which allows us to fully automate the requests process. 
We've changed mail provides from Proton to Disroot because it allows for the use of IMAP configs. 
Since emails are no longer e2e-encrypted through Proton's servers, I've changed the privacy policy too. 