### PR TITLE
Cloud wallpaper support

### DIFF
--- a/app/src/black/res/values/dashboard_configurations.xml
+++ b/app/src/black/res/values/dashboard_configurations.xml
@@ -23,4 +23,6 @@
         ]]>
     </string>
 
+    <string name="wallpaper_json">https://wallpapers.arcticons.com/config-black.json</string>
+
 </resources>

--- a/app/src/dayNight/res/values/dashboard_configurations.xml
+++ b/app/src/dayNight/res/values/dashboard_configurations.xml
@@ -23,4 +23,6 @@
         ]]>
     </string>
 
+    <string name="wallpaper_json">https://wallpapers.arcticons.com/config-daynight.json</string>
+
 </resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,11 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto">
 
-    <uses-permission android:name="android.permission.INTERNET" tools:node="remove" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" tools:node="remove"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" tools:node="remove" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" tools:node="remove" />
-    <uses-permission android:name="android.permission.SET_WALLPAPER" tools:node="remove" />
     <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove" />
     <uses-permission android:name="${applicationId}.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION" tools:node="remove" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove" />

--- a/app/src/main/res/values/dashboard_configurations.xml
+++ b/app/src/main/res/values/dashboard_configurations.xml
@@ -156,30 +156,15 @@
     <string name="regular_request_email_subject"></string>
     <string name="premium_request_email_subject"></string>
 
-    <!--
-        CONFIG: WALLPAPERS
-    -->
-    <!-- Wallpaper JSON link
-        If your icon pack doesn't contain any wallpaper, just leave this empty
-        <string name="wallpaper_json"></string>
-
-        If you want to separate wallpaper app from icon pack and keep wallpapers section shown in navigation drawer,
-        just put your wallpaper app's package name here
-        ex: com.dm.wallpaper.board.demo
-        <string name="wallpaper_json">com.dm.wallpaper.board.demo</string>
-        Now when "Wallpaper" section is selected in your icon pack app's navigation drawer,
-        your wallpaper app will be launched if it's installed. If it's not installed, then the Play Store page
-        will be opened to install your wallpaper app. -->
-    <string name="wallpaper_json"></string>
 
     <!-- Enable wallpaper downloading
         If disabled, your users will only be able to apply wallpapers from the dashboard.
         They will not be able to to download wallpapers.  -->
-    <bool name="enable_wallpaper_download">false</bool>
+    <bool name="enable_wallpaper_download">true</bool>
 
     <!-- Show name and author below wallpapers
         If you don't want to show name and author below wallpapers, just disable it (set it to `false`) -->
-    <bool name="wallpaper_show_name_author">false</bool>
+    <bool name="wallpaper_show_name_author">true</bool>
 
     <!-- Wallpapers grid preview style
         Available choices:
@@ -187,7 +172,7 @@
         - landscape
         - portrait
     -->
-    <string name="wallpaper_grid_preview_style">square</string>
+    <string name="wallpaper_grid_preview_style">portrait</string>
 
 
     <!--

--- a/app/src/normal/res/values/dashboard_configurations.xml
+++ b/app/src/normal/res/values/dashboard_configurations.xml
@@ -25,4 +25,6 @@
         ]]>
     </string>
 
+    <string name="wallpaper_json">https://wallpapers.arcticons.com/config-normal.json</string>
+
 </resources>

--- a/app/src/you/res/values/dashboard_configurations.xml
+++ b/app/src/you/res/values/dashboard_configurations.xml
@@ -23,4 +23,6 @@
         ]]>
     </string>
 
+    <string name="wallpaper_json">https://wallpapers.arcticons.com/config-you.json</string>
+
 </resources>


### PR DESCRIPTION
This adds support for custom wallpapers, hosted at https://github.com/Arcticons-Team/Wallpapers

Because they are cloud-based, that means, Arcticons need the **internet** permission as well as the **set-wallpaper** permission.