### PR TITLE
Update Appfilter

### DIFF
--- a/newicons/appfilter.xml
+++ b/newicons/appfilter.xml
@@ -29574,7 +29574,7 @@
 	<item component="ComponentInfo{com.wakdev.wdnfc/com.wakdev.nfctools.free.views.MainActivityFree}" drawable="nfctools"/>
 	<item component="ComponentInfo{com.wakdev.nfctools/com.wakdev.nfctools.free.MainActivityFree}" drawable="nfctools"/>
 	<item component="ComponentInfo{com.wakdev.nfctools.pro/com.wakdev.nfctools.pro.views.MainActivityPro}" drawable="nfctools"/>
-	<item component="ComponentInfo{de.fiduciagad.android.wlwallet/de.fiduciagad.android.vrwallet_module.ui.dispatcher.view.DispatcherActivity}" drawable="digitales_bezahlen"/>
+	<item component="ComponentInfo{de.fiduciagad.android.wlwallet/de.fiduciagad.android.vrwallet_module.ui.dispatcher.view.DispatcherActivity}" drawable="nfctools"/>
 
 	<!-- NFCGate -->
 	<item component="ComponentInfo{de.tu_darmstadt.seemoo.nfcgate/de.tu_darmstadt.seemoo.nfcgate.gui.MainActivity}" drawable="nfcgate"/>

--- a/newicons/appfilter.xml
+++ b/newicons/appfilter.xml
@@ -29574,6 +29574,7 @@
 	<item component="ComponentInfo{com.wakdev.wdnfc/com.wakdev.nfctools.free.views.MainActivityFree}" drawable="nfctools"/>
 	<item component="ComponentInfo{com.wakdev.nfctools/com.wakdev.nfctools.free.MainActivityFree}" drawable="nfctools"/>
 	<item component="ComponentInfo{com.wakdev.nfctools.pro/com.wakdev.nfctools.pro.views.MainActivityPro}" drawable="nfctools"/>
+	<item component="ComponentInfo{de.fiduciagad.android.wlwallet/de.fiduciagad.android.vrwallet_module.ui.dispatcher.view.DispatcherActivity}" drawable="digitales_bezahlen"/>
 
 	<!-- NFCGate -->
 	<item component="ComponentInfo{de.tu_darmstadt.seemoo.nfcgate/de.tu_darmstadt.seemoo.nfcgate.gui.MainActivity}" drawable="nfcgate"/>


### PR DESCRIPTION
"Digitales Bezahlen" is a german app that allows paying via NFC. It has a very similar icon to the default "Nfc tools", hence a new one isn't needed.