### PR TITLE
Update Appfilter

### DIFF
--- a/newicons/appfilter.xml
+++ b/newicons/appfilter.xml
@@ -4569,7 +4569,6 @@
 	<item component="ComponentInfo{se.dagsappar.beer/se.dagsappar.beer.app.BeerTimeActivity}" drawable="beerwithme"/>
 	<item component="ComponentInfo{se.dagsappar.beer/se.dagsappar.beer.MainActivity}" drawable="beerwithme"/>
 
-
 	<!-- BeeTV -->
 	<item component="ComponentInfo{com.busydev.audiocutter/com.busydev.audiocutter.SplashActivity}" drawable="beetv"/>
 

--- a/newicons/appfilter.xml
+++ b/newicons/appfilter.xml
@@ -4567,6 +4567,8 @@
 
 	<!-- Beer With Me -->
 	<item component="ComponentInfo{se.dagsappar.beer/se.dagsappar.beer.app.BeerTimeActivity}" drawable="beerwithme"/>
+	<item component="ComponentInfo{se.dagsappar.beer/se.dagsappar.beer.MainActivity}" drawable="beerwithme"/>
+
 
 	<!-- BeeTV -->
 	<item component="ComponentInfo{com.busydev.audiocutter/com.busydev.audiocutter.SplashActivity}" drawable="beetv"/>


### PR DESCRIPTION
The app "Beer With Me" doesn't use the proper icon anymore, since it changed for whatever reason its name to:
`se.dagsappar.beer/se.dagsappar.beer.MainActivity`

Still, I left the old app name on the _appfilter_ list, in case some people are still using the old version. If you prefer to keep the list as simple as possible, I can of course delete the old name :)

PS: and deleted an unnecessary line on the second commit