### PR TITLE
Add Bankinter Portugal to appfilter.xml

### DIFF
--- a/newicons/appfilter.xml
+++ b/newicons/appfilter.xml
@@ -4295,6 +4295,8 @@
 
 	<!-- Bankinter -->
 	<item component="ComponentInfo{com.bankinter.launcher/com.bankinter.launcher.Launcher}" drawable="bankinter"/>
+	<item component="ComponentInfo{com.bankinter.portugal.bmb/com.bankinter.portugal.bmb.app.ui.BMBPortugalSplashActivity}" drawable="bankinter"/>
+
 
 	<!-- Bankwest -->
 	<item component="ComponentInfo{au.com.bankwest.mobile/au.com.bankwest.mobile.activity.AppStartActivity}" drawable="bankwest"/>


### PR DESCRIPTION
The Bankinter app for Portugal does not work because it has a different name. I have updated it.