### PR TITLE
add utm_source=app

### DIFF
--- a/app/src/black/res/values/dashboard_configurations.xml
+++ b/app/src/black/res/values/dashboard_configurations.xml
@@ -15,7 +15,7 @@
         <![CDATA[
             <p>❄️ Arcticons is a line based <a href="https://github.com/Arcticons-Team/Arcticons">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
             <br>
-            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
+            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/?utm_source=app">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
             <br>
             <p>🎨 You can get priority icon requests <a href="https://ko-fi.com/donno_">on Ko-fi</a>, if you want your icons made within the next update.</p>
             <br>

--- a/app/src/dayNight/res/values/dashboard_configurations.xml
+++ b/app/src/dayNight/res/values/dashboard_configurations.xml
@@ -15,7 +15,7 @@
         <![CDATA[
             <p>❄️ Arcticons is a line based <a href="https://github.com/Arcticons-Team/Arcticons">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
             <br>
-            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
+            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/?utm_source=app">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
             <br>
             <p>🎨 You can get priority icon requests <a href="https://ko-fi.com/donno_">on Ko-fi</a>, if you want your icons made within the next update.</p>
             <br>

--- a/app/src/normal/res/values/dashboard_configurations.xml
+++ b/app/src/normal/res/values/dashboard_configurations.xml
@@ -17,7 +17,7 @@
         <![CDATA[
             <p>❄️ Arcticons is a line based <a href="https://github.com/Arcticons-Team/Arcticons">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
             <br>
-            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
+            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/?utm_source=app">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
             <br>
             <p>🎨 You can get priority icon requests <a href="https://ko-fi.com/donno_">on Ko-fi</a>, if you want your icons made within the next update.</p>
             <br>

--- a/app/src/you/res/values/dashboard_configurations.xml
+++ b/app/src/you/res/values/dashboard_configurations.xml
@@ -15,7 +15,7 @@
         <![CDATA[
             <p>❄️ Arcticons is a line based <a href="https://github.com/Arcticons-Team/Arcticons">open-source</a> icon-pack, brought to you by contributors all over the world!</p>
             <br>
-            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
+            <p>⚠️ If you need help with applying the icon pack, you can visit <a href="https://docs.arcticons.com/?utm_source=app">our knowledge base</a>. Or you can also <a href="mailto:hello@arcticons.com">email</a> me if you have questions :)</p>
             <br>
             <p>🎨 You can get priority icon requests <a href="https://ko-fi.com/donno_">on Ko-fi</a>, if you want your icons made within the next update.</p>
             <br>


### PR DESCRIPTION
This is adding the most simple refer possible to the apps, making it possible to give a bit more insight into the docs site.

<img width="473" alt="Scherm­afbeelding 2025-04-14 om 12 52 08" src="https://github.com/user-attachments/assets/c1390826-170a-4229-bb15-fe79a785ced9" />

