### PR TITLE
Smart Launcher patch

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -95,6 +95,8 @@
             <intent-filter>
                 <action android:name="org.adw.launcher.THEMES" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="org.icontheme.CHANGES_WITH_MATERIAL_YOU_COLORS" />
+                <category android:name="org.icontheme.FALLBACK_TO_THEMED_ICON" />
             </intent-filter>
             <!-- ADW Launcher Custom Icon Picker -->
             <intent-filter>

--- a/app/src/you/res/values-v31/colors.xml
+++ b/app/src/you/res/values-v31/colors.xml
@@ -11,6 +11,11 @@
     <color name="icon_color">@android:color/system_neutral2_700</color>
     <color name="icon_background_color">@android:color/system_accent1_100</color>
 
+
+    <!-- Smart Launcher theming -->
+    <color name="org.icontheme.icon_background_color">@color/icon_background_color</color>
+    <color name="org.icontheme.icon_color">@color/icon_color</color>
+
     <!-- Clock -->
     <color name="clockColor">@android:color/system_accent1_800</color>
 </resources>

--- a/app/src/you/res/values-v31/colors.xml
+++ b/app/src/you/res/values-v31/colors.xml
@@ -11,11 +11,6 @@
     <color name="icon_color">@android:color/system_neutral2_700</color>
     <color name="icon_background_color">@android:color/system_accent1_100</color>
 
-
-    <!-- Smart Launcher theming -->
-    <color name="org.icontheme.icon_background_color">@color/icon_background_color</color>
-    <color name="org.icontheme.icon_color">@color/icon_color</color>
-
     <!-- Clock -->
     <color name="clockColor">@android:color/system_accent1_800</color>
 </resources>

--- a/app/src/you/res/values/colors.xml
+++ b/app/src/you/res/values/colors.xml
@@ -11,6 +11,10 @@
     <color name="icon_color">#000</color>
     <color name="icon_background_color">#ffffffff</color>
 
+    <!-- Smart Launcher theming -->
+    <color name="org.icontheme.icon_background_color">@color/icon_background_color</color>
+    <color name="org.icontheme.icon_color">@color/icon_color</color>
+
     <!-- Clock -->
     <color name="clockColor">#000</color>
 </resources>


### PR DESCRIPTION
A patch making sure that material you icons work with the new Smart Launcher function that themes non-covered icons based on the color that we're using.