### PR TITLE
added 1 icon

### DIFF
--- a/newicons/saccas.svg
+++ b/newicons/saccas.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g>
+        <g>
+            <clipPath id="_clip1">
+                <path d="M22.247,18.007L23.142,13.919L37.807,14.817L41.578,24.678L41.377,46.66L24.989,46.94L8.324,45.696L7.741,33.403L8.375,19.67L16.598,15.385L18.628,18.706L11.986,22.722L14.969,24.847L19.5,25.786L19.5,32L28.5,32L28.576,27.385L28.514,25.5L27.227,18.475L22.247,18.007Z"/>
+            </clipPath>
+            <g clip-path="url(#_clip1)">
+                <circle cx="24" cy="32" r="4.5" style="fill:none;stroke:black;stroke-width:1px;"/>
+                <circle cx="24" cy="32" r="6.5" style="fill:none;stroke:black;stroke-width:1px;"/>
+                <circle cx="24" cy="32" r="11.5" style="fill:none;stroke:black;stroke-width:1px;"/>
+                <g id="X">
+                    <path d="M22.528,38.332L23.19,39.518" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M25.472,43.419L24.845,42.458" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M22.63,43.419L25.472,38.332" style="fill:none;stroke:black;stroke-width:1px;"/>
+                </g>
+                <g>
+                    <path d="M27.206,40.152L30.229,39.028" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M32.659,35.714L31.091,37.347" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M33.408,31.712L32.704,33.856" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M32.494,27.755L32.704,29.984" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M29.925,24.522L31.159,26.343" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M28.457,21.397L29.092,22.952" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M17.761,39.002L20.839,40.165" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M15.347,35.688L16.883,37.361" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M14.568,31.678L15.256,33.859" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M15.528,27.738L15.287,29.999" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M18.757,35.84L19.974,37.761" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M17.5,32L17.315,34.852" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M18.317,28.845L16.625,31.505" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M19.5,26.767L17.471,28.236" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M28.566,26.75L30.487,28.281" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M30.008,29.517L31.348,31.584" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M30.479,32.527L30.663,34.873" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M29.621,35.265L27.872,37.969" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M14.514,25.5L14.559,26.887" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M12.911,28.944L13.54,30.488" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M12.509,32.449L13.54,34.241" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M13.222,36.015L14.88,37.604" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M15.098,39.277L17.236,40.201" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M18.079,41.858L21.092,41.761" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M26.962,41.737L29.921,41.858" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M30.708,40.228L32.902,39.277" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M33.135,37.646L34.747,36.1" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M34.292,34.422L35.491,32.462" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M34.406,30.642L35.019,28.702" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M33.476,27.001L33.416,25.4" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M31.331,24.005L30.872,22.781" style="fill:none;stroke:black;stroke-width:1px;"/>
+                    <path d="M17.509,25.414L16.922,26.513" style="fill:none;stroke:black;stroke-width:1px;"/>
+                </g>
+            </g>
+        </g>
+        <g id="capricorn">
+            <path d="M19.5,32L19.5,25.786" style="fill:none;stroke:black;stroke-width:1px;"/>
+            <path d="M20.897,25.901C17.745,25.579 15.014,24.909 14.306,24.676C13.644,24.458 12.247,24.244 12.357,23.241" style="fill:none;stroke:black;stroke-width:1px;"/>
+            <path d="M15.51,23.226C15.51,23.226 11.799,24.22 11.903,22.011C11.964,20.707 12.456,20.373 12.902,20.065C13.394,19.726 17.381,17.443 17.381,17.443C17.381,17.443 17.405,16.324 19.312,14.904C18.315,14.078 16.925,13.009 17.914,10.588C18.49,12.06 20.048,13.262 20.048,13.262" style="fill:none;stroke:black;stroke-width:1px;"/>
+            <path d="M28.5,32C28.5,32 28.677,27.531 28.5,25.307C28.318,23.028 27.733,20.741 27.228,18.481C27.109,17.945 27.068,17.539 27.471,17.019C28.311,15.938 31.271,14.036 29.059,10.299C28.116,12.363 27.032,13.358 25.657,14.455C25.358,14.693 24.985,14.95 24.426,14.613C23.867,14.276 23.058,13.855 23.058,13.855" style="fill:none;stroke:black;stroke-width:1px;"/>
+            <path d="M23.058,13.855C22.889,10.663 22.853,8.158 23.547,6.485C23.977,5.447 25.507,4.232 26.85,5.92C27.033,6.15 24.942,3.083 23.045,5.056C22.084,6.055 20.915,9.174 21.393,12.927" style="fill:none;stroke:black;stroke-width:1px;"/>
+            <path d="M21.393,12.927C20.668,10.56 19.906,8.033 20.11,5.97C20.243,4.627 21.379,4.897 22.331,6.143C21.347,4.822 20.026,4.221 19.502,4.888C18.442,6.236 19.404,10.776 20.048,13.262" style="fill:none;stroke:black;stroke-width:1px;"/>
+        </g>
+        <g id="details">
+            <path d="M26.542,16.05C26.542,16.05 26.826,15.413 27.428,14.844C28.029,14.274 28.226,14.15 28.557,13.43" style="fill:none;stroke:black;stroke-width:1px;"/>
+            <path d="M19.5,29.187C19.5,29.187 19.942,31.523 21.518,32.782C22.426,32.169 29.111,26.216 27.554,19.913" style="fill:none;stroke:black;stroke-width:1px;"/>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Added icon for SAC CAS app. The original icon is very complicated, I simplified alot by reducing the logo to the head of the chamois. I wonder which level of detail you strive for:

Original icon:  
<img width="276" height="303" alt="saccas_original" src="https://github.com/user-attachments/assets/a1abddfd-f6b2-4a9f-813b-5a421afb3c77" />  

"Full" details:
<img width="276" height="276" alt="icon_saccas_fulldetails" src="https://github.com/user-attachments/assets/dab6b68a-5c1d-4dd9-bb23-d21d09f385e5" />  

My favourite (included in pull request):
<img width="276" height="276" alt="icon_saccas_favourite" src="https://github.com/user-attachments/assets/85e9d8cc-afbf-4abb-8083-b115da5011d5" />  

"No" details:
<img width="276" height="276" alt="icon_saccas_nodetails" src="https://github.com/user-attachments/assets/b4d9d99a-d53f-4784-8709-4f248ba7466b" />
