### PR TITLE
Sync to Codeberg via Action

### DIFF
--- a/.github/workflows/sync_to_codeberg.yml
+++ b/.github/workflows/sync_to_codeberg.yml
@@ -1,0 +1,28 @@
+# Syncs commits to the the Codeberg mirror
+name: Sync to Codeberg
+
+on:
+  push:
+    branches:
+        - "main"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+    sync-to-codeberg:
+      runs-on: ubuntu-latest
+      steps:
+      - name: Checking out branch
+        uses: actions/checkout@v7
+        with:
+            fetch-depth: 0
+      - name: Syncing
+        uses: yesolutions/mirror-action@v0.7.0
+        with:
+            REMOTE_NAME: "Codeberg"
+            REMOTE: 'https://codeberg.org/Arcticons/Arcticons-Android.git'
+            GIT_USERNAME: ${{ vars.CODEBERG_USERNAME }}
+            GIT_PASSWORD: ${{ secrets.CODEBERG_TOKEN }}
+            DEBUG: "true"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   [<img alt="Google Play" src="https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.donnnno.arcticons%26l%3DGoogle%2520Play%26m%3D%24version">](https://play.google.com/store/apps/details?id=com.donnnno.arcticons)
   [<img alt="GitHub" src="https://img.shields.io/github/downloads/donnnno/arcticons/total?label=github%20downloads">](https://github.com/Arcticons-Team/Arcticons/releases/latest) 
   [<img alt="GitHub" src="https://img.shields.io/github/downloads/donnnno/arcticons/latest/total">](https://github.com/Arcticons-Team/Arcticons/releases/latest) 
+  [![Sync to Codeberg](https://github.com/kitters-kat/Arcticons/actions/workflows/sync_to_codeberg.yml/badge.svg)](https://github.com/kitters-kat/Arcticons/actions/workflows/sync_to_codeberg.yml)
   
   ![Arcticons icon](github/arcticons.png)
 </div>


### PR DESCRIPTION
Took me a while of troubleshooting and second guessing before I figured out the problem I had was that syncing a whole 9 months of commits over HTTP always just times out. After I fast-forwarded the Codeberg repo manually, it worked fine. Just add a `CODEBERG_USERNAME` variable and a `CODEBERG_TOKEN` secret (with selective access to write to Arcticons/Arcticons-Android) to the repository. Alternatively, the username can be hardcoded, which is how I tested it out on my fork. Basically just took unnecessarily long to reengineer [this](https://github.com/Tuxilio/sync-test/blob/main/.github/workflows/sync_repo_github-forgejo.yml), but had to figure out how actions work along the way. Also added a badge!