### PR TITLE
Update SvgConverter.java - Fix for Moto Launcher not showing the clock icon.

### DIFF
--- a/preparehelper/src/main/java/com/donnnno/arcticons/helper/SvgConverter.java
+++ b/preparehelper/src/main/java/com/donnnno/arcticons/helper/SvgConverter.java
@@ -94,7 +94,8 @@ public class SvgConverter {
 
         root.addElement("background").addAttribute("android:drawable", "@color/icon_background_color");
 
-        Element inset = root.addElement("foreground").addElement("inset")
+        Element inset = root.addElement("foreground").addElement("layer-list").addElement("item")
+                .addElement("inset")
                 .addAttribute("android:inset", "25%");
 
         inset.add(svgRoot.createCopy());


### PR DESCRIPTION
The Lawnicons team discovered the fix:
https://github.com/LawnchairLauncher/lawnicons/issues/3942 

This changes how icons are generated, by adding an extra layer-list tag to it:


Old:
```
<?xml version="1.0" encoding="UTF-8"?>

<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
    <background android:drawable="@color/icon_background_color"/>
    <foreground>
        <inset android:inset="25%">
            <vector android:width="48dp" android:height="48dp" android:viewportWidth="48" android:viewportHeight="48">  
                <path android:strokeWidth="1.2" android:pathData="M24,2.5A21.5,21.5 0,1 1,2.5 24,21.51 21.51,0 0,1 24,2.5Z" android:strokeLineJoin="round" android:fillColor="#00000000" android:strokeColor="@color/icon_color" android:strokeLineCap="round"/>  
                <path android:strokeWidth="1.2" android:pathData="M24,24m-2.5,0a2.5,2.5 0,1 1,5 0a2.5,2.5 0,1 1,-5 0" android:strokeLineJoin="round" android:fillColor="#00000000" android:strokeColor="@color/icon_color" android:strokeLineCap="round"/>  
                <path android:strokeWidth="1.2" android:pathData="M24,21.5L24,11.44" android:strokeLineJoin="round" android:fillColor="#00000000" android:strokeColor="@color/icon_color" android:strokeLineCap="round"/>  
                <path android:strokeWidth="1.2" android:pathData="M26.1,25.35L38.3,33.15" android:strokeLineJoin="round" android:fillColor="#00000000" android:strokeColor="@color/icon_color" android:strokeLineCap="round"/> 
            </vector>
        </inset>
    </foreground>
</adaptive-icon>
```

New

```
<?xml version="1.0" encoding="UTF-8"?>

<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
    <background android:drawable="@color/icon_background_color"/>
    <foreground>
        <layer-list>
            <item>
                <inset android:inset="25%">
                    <vector android:width="48dp" android:height="48dp" android:viewportWidth="48" android:viewportHeight="48">  
                        <path android:strokeWidth="1.2" android:pathData="M24,2.5A21.5,21.5 0,1 1,2.5 24,21.51 21.51,0 0,1 24,2.5Z" android:strokeLineJoin="round" android:fillColor="#00000000" android:strokeColor="@color/icon_color" android:strokeLineCap="round"/>  
                        <path android:strokeWidth="1.2" android:pathData="M24,24m-2.5,0a2.5,2.5 0,1 1,5 0a2.5,2.5 0,1 1,-5 0" android:strokeLineJoin="round" android:fillColor="#00000000" android:strokeColor="@color/icon_color" android:strokeLineCap="round"/>  
                        <path android:strokeWidth="1.2" android:pathData="M24,21.5L24,11.44" android:strokeLineJoin="round" android:fillColor="#00000000" android:strokeColor="@color/icon_color" android:strokeLineCap="round"/>  
                        <path android:strokeWidth="1.2" android:pathData="M26.1,25.35L38.3,33.15" android:strokeLineJoin="round" android:fillColor="#00000000" android:strokeColor="@color/icon_color" android:strokeLineCap="round"/> 
                    </vector>
                </inset>
            </item>
        </layer-list>
    </foreground>
</adaptive-icon>
```


Closes #2636  