### PR TITLE
add BuildNightly.yml to test

### DIFF
--- a/.github/workflows/BuildNightly.yml
+++ b/.github/workflows/BuildNightly.yml
@@ -1,8 +1,8 @@
 name: Build Nightly
 on:
   schedule:
-    - cron: '00 12 * * 0-6'
-      timezone: "America/New_York"
+    - cron: '00 12 * * 6'
+      timezone: "Europe/Amsterdam"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/BuildNightly.yml
+++ b/.github/workflows/BuildNightly.yml
@@ -1,0 +1,60 @@
+name: Build Nightly
+on:
+  schedule:
+    - cron: '00 12 * * 0-6'
+      timezone: "America/New_York"
+  workflow_dispatch:
+
+permissions:
+  actions: none
+  attestations: none
+  checks: none
+  contents: read
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+concurrency:
+  group: 'nightly'
+  cancel-in-progress: false
+jobs:
+  buildNightly:
+    name: Build Arcticons APK Nightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checking out branch
+        uses: actions/checkout@v7
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: gradle
+      - name: Write sign info
+        run: "echo \"Workflow manually triggered by ${{ github.actor }}\"\nif [ ! -z \"${{ secrets.KEYSTORE }}\" ]; then\n  echo storePassword='${{ secrets.KEYSTORE_PASSWORD }}' >> keystore.properties\n  echo keyAlias='${{ secrets.KEY_ALIAS }}' >> keystore.properties\n  echo keyPassword='${{ secrets.KEY_PASSWORD }}' >> keystore.properties\n  echo storeFile='${{ github.workspace }}/key.jks' >> keystore.properties\n  echo ${{ secrets.KEYSTORE }} | base64 --decode > ${{ github.workspace }}/key.jks\nfi   \n"
+      - name: Get Gradle
+        run: gradle wrapper
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build Normal APK
+        run: ./gradlew app:assemblenormalRelease
+      - name: Build Black APK
+        run: ./gradlew app:assembleblackRelease
+      - name: Build You APK
+        run: ./gradlew app:assembleyouRelease
+      - name: Build Day&Night
+        run: ./gradlew app:assembledayNightRelease
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: |
+            app/build/outputs/apk/normal/nightly/*.apk
+            app/build/outputs/apk/black/nightly/*.apk
+            app/build/outputs/apk/dayNight/nightly/*.apk
+            app/build/outputs/apk/you/nightly/*.apk


### PR DESCRIPTION
Attempting to naively address #3501 by recycling code from signed debug release. It *seems* to work for me up to the point where gradle gets upset because I didn't add a key to sign with. Currently set to run daily at noon New York time, but that is easily configurable to run on a different schedule or whenever a commit is pushed. There might still be the matter of versioning and activity name to address (i.e. `Arcticons-normal-nightly-2026-08-12.apk` and `com.donnnno.arcticons.nightly`).