### PR TITLE
Add support for Password Store fork

### DIFF
--- a/newicons/appfilter.xml
+++ b/newicons/appfilter.xml
@@ -48587,6 +48587,7 @@
 	<item component="ComponentInfo{dev.msfjarvis.aps/dev.msfjarvis.aps.ui.main.LaunchActivity}" drawable="passwordstore"/>
 	<item component="ComponentInfo{dev.msfjarvis.aps/com.zeapo.pwdstore.PasswordStore}" drawable="passwordstore"/>
 	<item component="ComponentInfo{app.passwordstore/app.passwordstore.ui.main.LaunchActivity}" drawable="passwordstore"/>
+	<item component="ComponentInfo{app.passwordstore.agrahn/app.passwordstore.ui.main.LaunchActivity}" drawable="passwordstore"/>
 
 	<!-- Passwords -->
 	<item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.PasswordManagerShortcut}" drawable="passwords"/>


### PR DESCRIPTION
[Android Password Store](https://github.com/android-password-store/android-password-store) has been [archived for a while](https://github.com/android-password-store/Android-Password-Store/discussions/3260), so this simple PR adds support for a [maintained fork](https://github.com/agrahn/Android-Password-Store).