### PR TITLE
Enable app optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.db
 *.log
 *.dex
-*.pro
 *.yml
 *.jks
 *~
@@ -13,7 +12,6 @@ bin/
 build/
 release/
 gen/
-proguard/
 androidTest/
 test/
 mail/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ android {
     buildTypes {
         configureEach {
             signingConfig = signingConfigs.getByName("release")
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         release {
             optimization {
@@ -49,6 +50,9 @@ android {
         }
         debug {
             applicationIdSuffix = '.debug'
+            optimization {
+                enable = true
+            }
         }
         nightly {
             applicationIdSuffix = '.nightly'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,13 +43,18 @@ android {
             signingConfig = signingConfigs.getByName("release")
         }
         release {
-            minifyEnabled = false
+            optimization {
+                enable = true
+            }
         }
         debug {
             applicationIdSuffix = '.debug'
         }
         nightly {
             applicationIdSuffix = '.nightly'
+            optimization {
+                enable = true
+            }
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,26 @@
+# ProGuard rules for Arcticons
+
+# Room & WorkManager (Fixes crash on startup with AGP 9.0+ optimization)
+-keep class * extends androidx.room.RoomDatabase
+-keep class androidx.work.impl.WorkDatabase_Impl {
+    public <init>(android.content.Context);
+    public <init>();
+}
+
+# Keep Room generated classes
+-keep class androidx.room.RoomDatabase {
+    protected <init>();
+}
+-keep class * extends androidx.room.RoomDatabase
+-keep class * implements androidx.room.RoomOpenHelper
+
+# CandyBar Library
+-keep class candybar.lib.** { *; }
+
+# Keep all drawable resources for reflection (Essential for icon packs)
+-keep class com.donnnno.arcticons.R$drawable { *; }
+
+# General AGP 9.0 compatibility: keep constructors for classes that might be instantiated via reflection
+-keepclassmembers class * {
+    @androidx.room.Database *;
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.3.1'
+        classpath 'com.android.tools.build:gradle:9.3.2'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,8 @@ org.gradle.parallel=true
 android.useAndroidX=true
 android.nonTransitiveRClass=false
 android.enableJetifier=true
-
+android.r8.optimizedResourceShrinking=true
+android.r8.strictFullModeForKeepRules=false
 
 # Enabled parallel sync for Gradle 9.4+
 org.gradle.tooling.parallel=true


### PR DESCRIPTION
Got this warning in the Google Play dashboard:

1 issue requires attention

App optimization is below our threshold

Improve your rates in the following categories: Cloaking (1%). Rates below 25% in any category for your app may affect your visibility and publishing opportunities on Google Play. Optimize your app before the deadline to prevent this.

https://developer.android.com/topic/performance/app-optimization/enable-app-optimization