### PR TITLE
Update BuildNightly.yml to remove generate-notes

### DIFF
--- a/.github/workflows/BuildNightly.yml
+++ b/.github/workflows/BuildNightly.yml
@@ -74,4 +74,4 @@ jobs:
           
           $changelog
           "
-          gh release create $TAG_NAME --prerelease --generate-notes --fail-on-no-commits --title "$NAME" --notes "$NOTES" --target "$GITHUB_SHA" app/build/outputs/apk/normal/nightly/*.apk app/build/outputs/apk/black/nightly/*.apk app/build/outputs/apk/dayNight/nightly/*.apk app/build/outputs/apk/you/nightly/*.apk generated/releaseImage.webp
+          gh release create $TAG_NAME --prerelease --fail-on-no-commits --title "$NAME" --notes "$NOTES" --target "$GITHUB_SHA" app/build/outputs/apk/normal/nightly/*.apk app/build/outputs/apk/black/nightly/*.apk app/build/outputs/apk/dayNight/nightly/*.apk app/build/outputs/apk/you/nightly/*.apk generated/releaseImage.webp


### PR DESCRIPTION
Removed the --generate-notes option from the release command since it's kinda annoying for prereleases 